### PR TITLE
Without arguments, `remove_all_listeners()` will remove all listeners for all events

### DIFF
--- a/pyee/__init__.py
+++ b/pyee/__init__.py
@@ -62,11 +62,14 @@ class EventEmitter(object):
         """
         self._events[event].remove(function)
 
-    def remove_all_listeners(self, event):
+    def remove_all_listeners(self, event=None):
+        """Remove all listeners attached to `event`. 
         """
-        Remove all listeners attached to `event`.
-        """
-        self._events[event] = []
+        if event is not None:
+            self._events[event] = []
+        else:
+            self._events = None
+            self._events = defaultdict(list)
 
     def listeners(self, event):
         return self._events[event]


### PR DESCRIPTION
This is consistent with the behavior of [the Node.js counterpart](http://nodejs.org/api/events.html#events_emitter_removealllisteners_event).
