### PR TITLE
Preserve properties of decorated functions

### DIFF
--- a/pyee/__init__.py
+++ b/pyee/__init__.py
@@ -128,10 +128,14 @@ class EventEmitter(object):
                 self.remove_listener(event, g)
             return g
 
-        if f is None:
-            return lambda f: self.on(event, _once(f))
-        else:
+        def _wrapper(f):
             self.on(event, _once(f))
+            return f
+
+        if f is None:
+            return _wrapper
+        else:
+            _wrapper(f)
 
     def remove_listener(self, event, f):
         """Removes the function ``f`` from ``event``.

--- a/test/tests.py
+++ b/test/tests.py
@@ -153,3 +153,34 @@ def test_listeners():
 
     with nt.assert_raises(ItWorkedException) as it_worked:
         ee.emit('event')
+
+def test_properties_preserved():
+    """Test that the properties of decorated functions are preserved.
+    """
+    ee = EventEmitter()
+
+    @ee.on('always')
+    def always_event_handler():
+        """An event handler."""
+        raise ItWorkedException
+
+    @ee.once('once')
+    def once_event_handler():
+        """Another event handler."""
+        raise ItWorkedException
+
+    nt.assert_equal(always_event_handler.__doc__, 'An event handler.')
+    nt.assert_equal(once_event_handler.__doc__, 'Another event handler.')
+
+    with nt.assert_raises(ItWorkedException) as it_worked:
+        # Call the event handler directly.
+        always_event_handler()
+
+    with nt.assert_raises(ItWorkedException):
+        # Call the event handler directly.
+        once_event_handler()
+
+    with nt.assert_raises(ItWorkedException):
+        # Assert that it does not matter, that the handler has already been
+        # called directly.
+        ee.emit('once')


### PR DESCRIPTION
The properties (name, docstring, ...) of decorated functions should be preserved. Always return the original function from decorators.