### PR TITLE
Inherit from object to allow easier inheritance of EventEmitter

### DIFF
--- a/pyee/__init__.py
+++ b/pyee/__init__.py
@@ -42,7 +42,7 @@ class PyeeException(Exception):
     pass
 
 
-class EventEmitter():
+class EventEmitter(object):
     """The EventEmitter class.
 
     For interoperation with asyncio, one can specify the scheduler and

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -240,14 +240,22 @@ def test_inheritance():
     assert EventEmitter in getmro(example)
     assert object in getmro(example)
 
-
 def test_multiple_inheritance():
     """Test that inheritance is preserved along a lengthy MRO"""
-    example = EventEmitter
+    class example(EventEmitter):
+        def __init__(self):
+            super(example, self).__init__()
 
-    for _ in range(10):
-        class example(example):
-            def __init__(self):
-                super(example, self).__init__()
+    class _example(example):
+        def __init__(self):
+            super(_example, self).__init__()
 
-    a = example()
+    class example2(_example):
+        def __init__(self):
+            super(example2, self).__init__()
+
+    class _example2(_example):
+        def __init__(self):
+            super(_example2, self).__init__()
+
+    a = _example2()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from inpsect import getmro
+from inspect import getmro
 
 from mock import Mock
 from pytest import raises

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from inpsect import getmro
+
 from mock import Mock
 from pytest import raises
 
@@ -225,3 +227,27 @@ def test_properties_preserved():
     # Calling the event handler directly doesn't clear the handler
     ee.emit('once')
     call_me_also.assert_called_once()
+
+
+def test_inheritance():
+    """Test that inheritance is preserved from object"""
+    assert object in getmro(EventEmitter)
+
+    class example(EventEmitter):
+        def __init__(self):
+            super(example, self).__init__()
+
+    assert EventEmitter in getmro(example)
+    assert object in getmro(example)
+
+
+def test_multiple_inheritance():
+    """Test that inheritance is preserved along a lengthy MRO"""
+    example = EventEmitter
+
+    for _ in range(10):
+        class example(example):
+            def __init__(self):
+                super(example, self).__init__()
+
+    a = example()


### PR DESCRIPTION
Right now I need to inherit from both EventEmitter *and* object if I want to build off of your class.

If you inherit from object, then I don't need to manage multiple inheritance. It's the difference between

```python
class Example(EventEmitter, object):
    def __init__(self):
        """This is gross, and can cause MRO errors"""
        object.__init__(self)
        EventEmitter.__init__(self)
```

and

```python
class Example(EventEmitter):
    def __init__(self):
        """This is cleaner, and the recommended style"""
        super(example, self).__init__()
```