### PR TITLE
Now possible to remove once handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+  - once now returns the wrapped function when called in non-decorating form
   - Minor stylistic tweaks to make code more pythonic
 
 2017/11/17 Version 4.0.1

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -174,6 +174,26 @@ def test_once():
     assert ee._events['event'] == []
 
 
+def test_once_removal():
+    """Removal of once functions works
+    """
+
+    ee = EventEmitter()
+
+    def once_handler(data):
+        pass
+
+    handle = ee.once('event', once_handler)
+
+    assert handle != once_handler, (
+        'Handle returned by once call is the wrapped handler'
+    )
+
+    ee.remove_listener('event', handle)
+
+    assert ee._events['event'] == []
+
+
 def test_listeners():
     """`listeners()` gives you access to the listeners array."""
 


### PR DESCRIPTION
It's kind of an awkward behavior, but it preserves the unwrapped decorated function behavior while adding the possibility of removing the event handler.

Another option is to lose the existing properties of decorated once handlers (which like on handlers returns the original function), in return for once always returning the same function.

There is, of course, also the option of making a more complicated data structure to store both the handler function and the original handler key, but I don't want to go down that road.