### PR TITLE
once handlers much better behaved; internal refactor to support that; necessary and sane changes to listeners method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ dist/*
 build/*
 MANIFEST
 README
+.cache
+.eggs
+.python-version
+pyee.egg-info/
+version.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+  - once now returns the wrapped function when called in non-decorating form
   - Minor stylistic tweaks to make code more pythonic
 
 2017/11/17 Version 4.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-  - once now returns the wrapped function when called in non-decorating form
+  - The `listeners` method no longer returns the raw list of listeners;
+    mutating listeners on the EE with this method no longer works.
+  - Possible to remove once handlers, as internally listeners are now keyed
+    by the unwrapped handler
   - Minor stylistic tweaks to make code more pythonic
 
 2017/11/17 Version 4.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
   - The `listeners` method no longer returns the raw list of listeners;
-    mutating listeners on the EE with this method no longer works.
-  - Possible to remove once handlers, as internally listeners are now keyed
-    by the unwrapped handler
+    mutating listeners on the EventEmitter by mutating the list returned by
+    this method isn't possible anymore
+  - `once` API now returns the unwrapped handler in both decorator and
+    non-decorator cases
+  - Possible to remove once handlers with unwrapped handlers
+  - Internally, listeners are now stored on a OrderedDict rather than a list
   - Minor stylistic tweaks to make code more pythonic
 
 2017/11/17 Version 4.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-  - The `listeners` method no longer returns the raw list of listeners;
-    mutating listeners on the EventEmitter by mutating the list returned by
-    this method isn't possible anymore
+  - The `listeners` method no longer returns the raw list of listeners, and
+    instead returns a list of unwrapped listeners; This means that mutating
+    listeners on the EventEmitter by mutating the list returned by
+    this method isn't possible anymore, and that for once handlers this method
+    returns the unwrapped handler rather than the wrapped handler
   - `once` API now returns the unwrapped handler in both decorator and
     non-decorator cases
   - Possible to remove once handlers with unwrapped handlers

--- a/pyee/__init__.py
+++ b/pyee/__init__.py
@@ -181,32 +181,6 @@ class EventEmitter(object):
     def once(self, event, f=None):
         """The same as ``ee.on``, except that the listener is automatically
         removed after being called.
-
-        A subtle difference in behavior between the decorated and
-        undecorated versions of this function: As an implementation detail,
-        the event handler is wrapped in a function which removes itself from
-        listeners right before the wrapped listener is called. The decorator
-        version returns the underlying function, while the non-decorating call
-        returns the wrapped handler. This means that this will work::
-
-            h = ee.once('event', once_handler)
-
-            ee.remove_listener('event', h)
-
-        However::
-
-            @ee.once('event')
-            def once_handler():
-                print('hello')
-
-            # This won't remove anything, since once_handler isn't the
-            # wrapped listener
-            ee.remove_listener('event', once_handler)
-
-            # But, I can call it without removing the event
-            once_handler()  # Prints "hello", event still attached
-            ee.emit('event')  # Still prints "hello"
-            ee.emit('event')  # Does nothing, event self-removed
         """
         def _wrapper(f):
             def g(*args, **kwargs):

--- a/pyee/__init__.py
+++ b/pyee/__init__.py
@@ -209,7 +209,7 @@ class EventEmitter(object):
         If ``event`` is ``None``, remove all listeners on all events.
         """
         if event is not None:
-            self._events[event] = {}
+            self._events[event] = OrderedDict()
         else:
             self._events = defaultdict(OrderedDict)
 

--- a/pyee/__init__.py
+++ b/pyee/__init__.py
@@ -105,8 +105,8 @@ class EventEmitter(object):
         scheduling function (defaults to ``asyncio.ensure_future``) and the
         configured event loop (defaults to ``asyncio.get_event_loop()``).
 
-        In both the decorated and undecorated forms, the function handler
-        is returned. The upshot of this is that you can call decorated handlers
+        In both the decorated and undecorated forms, the event handler is
+        returned. The upshot of this is that you can call decorated handlers
         directly, as well as use them in remove_listener calls.
         """
 

--- a/pyee/__init__.py
+++ b/pyee/__init__.py
@@ -33,7 +33,6 @@ except ImportError:
     ensure_future = None
 
 from collections import defaultdict
-from functools import wraps
 
 __all__ = ['EventEmitter', 'PyeeException']
 
@@ -79,7 +78,7 @@ class EventEmitter(object):
       no facilities for handling returned Promises from handlers.
     """
     def __init__(self, scheduler=ensure_future, loop=None):
-        self._events = defaultdict(list)
+        self._events = defaultdict(dict)
         self._schedule = scheduler
         self._loop = loop
 
@@ -112,18 +111,20 @@ class EventEmitter(object):
         """
 
         def _on(f):
-            # Fire 'new_listener' *before* adding the new listener!
-            self.emit('new_listener', event, f)
-
-            # Add the necessary function
-            self._events[event].append(f)
-
+            self._add_event_handler(event, f, f)
             return f
 
         if f is None:
             return _on
         else:
             return _on(f)
+
+    def _add_event_handler(self, event, k, v):
+        # Fire 'new_listener' *before* adding the new listener!
+        self.emit('new_listener', event, k)
+
+        # Add the necessary function
+        self._events[event][k] = v
 
     def emit(self, event, *args, **kwargs):
         """Emit ``event``, passing ``*args`` and ``**kwargs`` to each attached
@@ -143,7 +144,7 @@ class EventEmitter(object):
         """
         handled = False
 
-        for f in self._events[event][:]:
+        for f in list(self._events[event].values()):
             result = f(*args, **kwargs)
 
             # If f was a coroutine function, we need to schedule it and
@@ -207,38 +208,35 @@ class EventEmitter(object):
             ee.emit('event')  # Still prints "hello"
             ee.emit('event')  # Does nothing, event self-removed
         """
-        def _once(f):
-            @wraps(f)
+        def _wrapper(f):
             def g(*args, **kwargs):
-                self.remove_listener(event, g)
+                self.remove_listener(event, f)
                 # f may return a coroutine, so we need to return that
                 # result here so that emit can schedule it
                 return f(*args, **kwargs)
-            return g
 
-        def _decorator(f):
-            self.on(event, _once(f))
+            self._add_event_handler(event, f, g)
             return f
 
         if f is None:
-            return _decorator
+            return _wrapper
         else:
-            return self.on(event, _once(f))
+            return _wrapper(f)
 
     def remove_listener(self, event, f):
         """Removes the function ``f`` from ``event``."""
-        self._events[event].remove(f)
+        self._events[event].pop(f)
 
     def remove_all_listeners(self, event=None):
         """Remove all listeners attached to ``event``.
         If ``event`` is ``None``, remove all listeners on all events.
         """
         if event is not None:
-            self._events[event] = []
+            self._events[event] = {}
         else:
-            self._events = defaultdict(list)
+            self._events = defaultdict(dict)
 
     def listeners(self, event):
-        """Returns the list of all listeners registered to the ``event``.
+        """Returns a list of all listeners registered to the ``event``.
         """
-        return self._events[event]
+        return list(self._events[event].values())

--- a/pyee/__init__.py
+++ b/pyee/__init__.py
@@ -216,4 +216,4 @@ class EventEmitter(object):
     def listeners(self, event):
         """Returns a list of all listeners registered to the ``event``.
         """
-        return list(self._events[event].values())
+        return list(self._events[event].keys())

--- a/pyee/__init__.py
+++ b/pyee/__init__.py
@@ -32,7 +32,7 @@ except ImportError:
     iscoroutine = None
     ensure_future = None
 
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 
 __all__ = ['EventEmitter', 'PyeeException']
 
@@ -78,7 +78,7 @@ class EventEmitter(object):
       no facilities for handling returned Promises from handlers.
     """
     def __init__(self, scheduler=ensure_future, loop=None):
-        self._events = defaultdict(dict)
+        self._events = defaultdict(OrderedDict)
         self._schedule = scheduler
         self._loop = loop
 
@@ -234,7 +234,7 @@ class EventEmitter(object):
         if event is not None:
             self._events[event] = {}
         else:
-            self._events = defaultdict(dict)
+            self._events = defaultdict(OrderedDict)
 
     def listeners(self, event):
         """Returns a list of all listeners registered to the ``event``.

--- a/pyee/__init__.py
+++ b/pyee/__init__.py
@@ -124,6 +124,9 @@ class EventEmitter(object):
         self.emit('new_listener', event, k)
 
         # Add the necessary function
+        # Note that k and v are the same for `on` handlers, but
+        # different for `once` handlers, where v is a wrapped version
+        # of k which removes itself before calling k
         self._events[event][k] = v
 
     def emit(self, event, *args, **kwargs):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -105,17 +105,26 @@ def test_listener_removal():
 
     ee.on('event', fourth)
 
-    assert ee._events['event'] == [first, second, third, fourth]
+    assert ee._events['event'] == {
+        first: first,
+        second: second,
+        third: third,
+        fourth: fourth
+    }
 
     ee.remove_listener('event', second)
 
-    assert ee._events['event'] == [first, third, fourth]
+    assert ee._events['event'] == {
+        first: first,
+        third: third,
+        fourth: fourth
+    }
 
     ee.remove_listener('event', first)
-    assert ee._events['event'] == [third, fourth]
+    assert ee._events['event'] == {third: third, fourth: fourth}
 
     ee.remove_all_listeners('event')
-    assert ee._events['event'] == []
+    assert ee._events['event'] == {}
 
 
 def test_listener_removal_on_emit():
@@ -165,13 +174,11 @@ def test_once():
     # Tests to make sure that after event is emitted that it's gone.
     callback_fn = ee.once('event', once_handler)
 
-    # assert ee._events['event'] == [callback_fn]
-
     ee.emit('event', 'emitter is emitted!')
 
     call_me.assert_called_once()
 
-    assert ee._events['event'] == []
+    assert ee._events['event'] == {}
 
 
 def test_once_removal():
@@ -185,17 +192,15 @@ def test_once_removal():
 
     handle = ee.once('event', once_handler)
 
-    assert handle != once_handler, (
-        'Handle returned by once call is the wrapped handler'
-    )
+    assert handle == once_handler
 
     ee.remove_listener('event', handle)
 
-    assert ee._events['event'] == []
+    assert ee._events['event'] == {}
 
 
 def test_listeners():
-    """`listeners()` gives you access to the listeners array."""
+    """`listeners()` returns a copied list of listeners."""
 
     call_me = Mock()
     ee = EventEmitter()
@@ -208,12 +213,12 @@ def test_listeners():
 
     assert listeners[0] == event_handler
 
-    # Overwrite listener
+    # listeners is a copy, you can't mutate the innards this way
     listeners[0] = call_me
 
     ee.emit('event')
 
-    call_me.assert_called_once()
+    call_me.assert_not_called()
 
 
 def test_properties_preserved():

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -174,6 +174,26 @@ def test_once():
     assert ee._events['event'] == []
 
 
+def test_once_removal():
+    """Removal of once functions works
+    """
+
+    ee = EventEmitter()
+
+    def once_handler(data):
+        pass
+
+    handle = ee.once('event', once_handler)
+
+    assert handle != once_handler, (
+        'Handle returned by once call is the wrapped handler'
+    )
+
+    ee.remove_listener('event', handle)
+
+    assert ee._events['event'] == []
+
+
 def test_listeners():
     """`listeners()` gives you access to the listeners array."""
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -210,9 +210,14 @@ def test_listeners():
     def event_handler():
         pass
 
+    @ee.once('event')
+    def once_handler():
+        pass
+
     listeners = ee.listeners('event')
 
     assert listeners[0] == event_handler
+    assert listeners[1] == once_handler
 
     # listeners is a copy, you can't mutate the innards this way
     listeners[0] = call_me

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from inspect import getmro
+from collections import OrderedDict
 
 from mock import Mock
 from pytest import raises
@@ -105,26 +106,26 @@ def test_listener_removal():
 
     ee.on('event', fourth)
 
-    assert ee._events['event'] == {
-        first: first,
-        second: second,
-        third: third,
-        fourth: fourth
-    }
+    assert ee._events['event'] == OrderedDict([
+        (first, first),
+        (second, second),
+        (third, third),
+        (fourth, fourth)
+    ])
 
     ee.remove_listener('event', second)
 
-    assert ee._events['event'] == {
-        first: first,
-        third: third,
-        fourth: fourth
-    }
+    assert ee._events['event'] == OrderedDict([
+        (first, first),
+        (third, third),
+        (fourth, fourth)
+    ])
 
     ee.remove_listener('event', first)
-    assert ee._events['event'] == {third: third, fourth: fourth}
+    assert ee._events['event'] == OrderedDict([(third, third), (fourth, fourth)])
 
     ee.remove_all_listeners('event')
-    assert ee._events['event'] == {}
+    assert ee._events['event'] == OrderedDict()
 
 
 def test_listener_removal_on_emit():
@@ -178,7 +179,7 @@ def test_once():
 
     call_me.assert_called_once()
 
-    assert ee._events['event'] == {}
+    assert ee._events['event'] == OrderedDict()
 
 
 def test_once_removal():
@@ -196,7 +197,7 @@ def test_once_removal():
 
     ee.remove_listener('event', handle)
 
-    assert ee._events['event'] == {}
+    assert ee._events['event'] == OrderedDict()
 
 
 def test_listeners():


### PR DESCRIPTION
Alternative to #39. Uses an OrderedDict instead of a list for storing events, so that we can key them by unwrapped functions.

Note that the `listeners` method no longer returns the raw events object but a list of its items as a snapshot; in other words, you can't mutate the listeners list directly anymore.