### PR TITLE
Add error handling for sync functions which return Deferreds

### DIFF
--- a/pyee/__init__.py
+++ b/pyee/__init__.py
@@ -171,6 +171,10 @@ class EventEmitter(object):
                     @d.addErrback
                     def _callback(exc):
                         self.emit('error', exc)
+            elif hasattr(result, 'addErrback'):
+                @result.addErrback
+                def _callback(exc):
+                    self.emit('error', exc)
             handled = True
 
         if not handled and event == 'error':

--- a/tests/test_deferred.py
+++ b/tests/test_deferred.py
@@ -7,6 +7,11 @@ from twisted.internet.defer import inlineCallbacks, succeed
 
 from pyee import EventEmitter
 
+
+class PyeeTestError(Exception):
+    pass
+
+
 def test_propagates_error():
     """Test that event_emitters can propagate errors
     from twisted Deferreds

--- a/tests/test_deferred.py
+++ b/tests/test_deferred.py
@@ -3,7 +3,7 @@
 import pytest
 
 from mock import Mock
-from twisted.internet.defer import inlineCallbacks, succeed
+from twisted.internet.defer import fail, inlineCallbacks, succeed
 
 from pyee import EventEmitter
 
@@ -23,7 +23,7 @@ def test_propagates_error():
     @ee.on('event')
     @inlineCallbacks
     def event_handler():
-        raise PyeeTestError()
+        yield failure(PyeeTestError())
 
     @ee.on('error')
     def handle_error(e):

--- a/tests/test_deferred.py
+++ b/tests/test_deferred.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from mock import Mock
+from twisted.internet.defer import inlineCallbacks, succeed
+
+from pyee import EventEmitter
+
+def test_propagates_error():
+    """Test that event_emitters can propagate errors
+    from twisted Deferreds
+    """
+    ee = EventEmitter()
+
+    should_call = Mock()
+
+    @ee.on('event')
+    @inlineCallbacks
+    def event_handler():
+        raise PyeeTestError()
+
+    @ee.on('error')
+    def handle_error(e):
+        should_call(e)
+
+    ee.emit('event')
+
+    should_call.assert_called_once()


### PR DESCRIPTION
Proposed way of making @inlineCallbacks-decorated generators work well with EventEmitter, as a way of supporting "coroutine-like" handlers in python 2.

/cc @Roach