### PR TITLE
Smart imports approach that doesn't use module-level __getattr__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ README
 .python-version
 pyee.egg-info/
 version.txt
+scratchpad.ipynb

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,12 @@ API Docs:
 .. autoclass:: pyee._compat.CompatEventEmitter
     :members:
 
+.. autoclass:: pyee.PyeeException
+
+.. autoclass:: pyee.UnspecifiedErrorException
+
+.. autoclass:: pyee.LazyImportException
+
 
 Some Links
 ==========

--- a/pyee/__init__.py
+++ b/pyee/__init__.py
@@ -52,8 +52,6 @@ class LazyImportException(PyeeException):
     object, but the lazy loading system can't tell which is which. Moreover,
     the error message can not be customized when inheriting from either.
     '''
-    def __init__(self, *args, **kwargs):
-        return PyeeException.__init__(self, *args, **kwargs)
 
 
 LAZY_IMPORTS = {

--- a/pyee/_base.py
+++ b/pyee/_base.py
@@ -10,6 +10,13 @@ class PyeeException(Exception):
     pass
 
 
+class UnspecifiedErrorException(Exception):
+    """An exception raised when an ``error`` event occurs without an
+    Exception to raise.
+    """
+    pass
+
+
 class BaseEventEmitter(object):
     """The base event emitter class. All other event emitters inherit from
     this class.
@@ -82,7 +89,9 @@ class BaseEventEmitter(object):
             if error:
                 raise error
             else:
-                raise PyeeException("Uncaught, unspecified 'error' event.")
+                raise UnspecifiedErrorException(
+                    "Uncaught, unspecified 'error' event."
+                )
 
     def emit(self, event, *args, **kwargs):
         """Emit ``event``, passing ``*args`` and ``**kwargs`` to each attached

--- a/pyee/_base.py
+++ b/pyee/_base.py
@@ -7,14 +7,12 @@ __all__ = ['BaseEventEmitter', 'PyeeException']
 
 class PyeeException(Exception):
     """An exception internal to pyee."""
-    pass
 
 
 class UnspecifiedErrorException(Exception):
     """An exception raised when an ``error`` event occurs without an
     Exception to raise.
     """
-    pass
 
 
 class BaseEventEmitter(object):


### PR DESCRIPTION
Alternative to #54 that tries to avoid using module-level __getattr__ but breaks for its own reasons.