### PR TITLE
Support handling cancellations in AsyncIOEventEmitter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,5 @@
 - Added a ``TrioEventEmitter`` class for intended use with trio
+- ``AsyncIOEventEmitter`` now correctly handles cancellations
 
 2019/04/11 Version 6.0.0
 -----------------------

--- a/pyee/_asyncio.py
+++ b/pyee/_asyncio.py
@@ -54,6 +54,9 @@ class AsyncIOEventEmitter(BaseEventEmitter):
             if f:
                 @f.add_done_callback
                 def _callback(f):
+                    if f.cancelled():
+                        return
+
                     exc = f.exception()
                     if exc:
                         self.emit('error', exc)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -114,8 +114,7 @@ async def test_asyncio_cancellation(event_loop):
     ee.emit('event')
 
     try:
-        result = await wait_for(should_not_call, 0.1)
-        assert not result
+        await wait_for(should_not_call, 0.1)
     except TimeoutError:
         pass
     else:


### PR DESCRIPTION
Fixes #64 by detecting cancellations and doing nothing.

This PR punts on adding a "cancelled" event because the event isn't useful unless I emit the listener as in the "new_listener" event and the current code isn't structured to enable that.