### PR TITLE
Update Deprecation Warning

### DIFF
--- a/pyee/_compat.py
+++ b/pyee/_compat.py
@@ -36,7 +36,8 @@ class CompatEventEmitter(BaseEventEmitter):
             'pyee.EventEmitter is deprecated and will be removed in a future '
             'major version; you should instead use either '
             'pyee.AsyncIOEventEmitter, pyee.TwistedEventEmitter, '
-            'pyee.ExecutorEventEmitter or pyee.BaseEventEmitter.'
+            'pyee.ExecutorEventEmitter, pyee.TrioEventEmitter, '
+            ' or pyee.BaseEventEmitter.'
         ))
 
         super(CompatEventEmitter, self).__init__()


### PR DESCRIPTION
I noticed the deprecation warning didn't call out the new `TrioEventEmitter`, so here it is.