### PR TITLE
Namespace support

### DIFF
--- a/pyee/namespace.py
+++ b/pyee/namespace.py
@@ -38,16 +38,20 @@ class NamespaceEventEmitter(BaseEventEmitter):
         if isinstance(namespace, tuple):
             for step in range(len(namespace)):
                 handled = (
-                    super()._call_handlers(namespace[: step + 1], args, kwargs)
+                    super(NamespaceEventEmitter, self)._call_handlers(
+                        namespace[: step + 1], args, kwargs
+                    )
                     or handled
                 )
         else:
-            handled = super()._call_handlers(namespace, args, kwargs)
+            handled = super(NamespaceEventEmitter, self)._call_handlers(
+                namespace, args, kwargs
+            )
 
         return handled
 
     def _emit_handle_potential_error(self, namespace, error):
-        return super()._emit_handle_potential_error(
+        return super(NamespaceEventEmitter, self)._emit_handle_potential_error(
             "error"
             if isinstance(namespace, tuple) and namespace[0] == "error"
             else namespace,
@@ -55,22 +59,34 @@ class NamespaceEventEmitter(BaseEventEmitter):
         )
 
     def on(self, event, f=None):
-        return super().on(self._to_namespace(event), f)
+        return super(NamespaceEventEmitter, self).on(
+            self._to_namespace(event), f
+        )
 
     def emit(self, event, *args, **kwargs):
-        return super().emit(self._to_namespace(event), *args, **kwargs)
+        return super(NamespaceEventEmitter, self).emit(
+            self._to_namespace(event), *args, **kwargs
+        )
 
     def once(self, event, f=None):
-        return super().once(self._to_namespace(event), f)
+        return super(NamespaceEventEmitter, self).once(
+            self._to_namespace(event), f
+        )
 
     def listeners(self, event):
-        return super().listeners(self._to_namespace(event))
+        return super(NamespaceEventEmitter, self).listeners(
+            self._to_namespace(event)
+        )
 
     def remove_listener(self, event, f):
-        return super().remove_listener(self._to_namespace(event), f)
+        return super(NamespaceEventEmitter, self).remove_listener(
+            self._to_namespace(event), f
+        )
 
     def remove_all_listeners(self, event=None):
-        return super().remove_all_listeners(self._to_namespace(event))
+        return super(NamespaceEventEmitter, self).remove_all_listeners(
+            self._to_namespace(event)
+        )
 
 
 try:

--- a/pyee/namespace.py
+++ b/pyee/namespace.py
@@ -1,0 +1,103 @@
+from pyee import BaseEventEmitter
+
+__all__ = ["NamespaceEventEmitter"]
+
+
+class NamespaceEventEmitter(BaseEventEmitter):
+    """TODO"""
+
+    NAMESPACE_BLACKLIST = ("new_listener",)
+
+    @classmethod
+    def _to_namespace(cls, event):
+        if isinstance(event, tuple):
+            if len(event) == 0:
+                raise TypeError("Namespace tuples must have at least one entry")
+
+            if event[0] in cls.NAMESPACE_BLACKLIST:
+                raise RuntimeError(
+                    "%s is a blacklisted namespace. It can only be emitted/listened as a simple event"
+                )
+
+            return event
+
+        if event in cls.NAMESPACE_BLACKLIST:
+            return event
+
+        return (event,)
+
+    def _call_handlers(self, namespace, args, kwargs):
+        handled = False
+
+        if isinstance(namespace, tuple):
+            for step in range(len(namespace)):
+                handled = super()._call_handlers(namespace[: step + 1], args, kwargs)
+        else:
+            handled = super()._call_handlers(namespace, args, kwargs)
+
+        return handled
+
+    def _emit_handle_potential_error(self, namespace, error):
+        return super()._emit_handle_potential_error(
+            "error"
+            if isinstance(namespace, tuple) and namespace[0] == "error"
+            else namespace,
+            error,
+        )
+
+    def emit(self, event, *args, **kwargs):
+        return super().emit(self._to_namespace(event), *args, **kwargs)
+
+    def once(self, event, f=None):
+        return super().once(self._to_namespace(event), f)
+
+    def listeners(self, event):
+        return super().listeners(self._to_namespace(event))
+
+    def remove_listener(self, event, f):
+        return super().remove_listener(self._to_namespace(event), f)
+
+    def remove_all_listeners(self, event=None):
+        return super().remove_all_listeners(self._to_namespace(event))
+
+
+try:
+    from pyee._asyncio import AsyncIOEventEmitter  # noqa
+
+    class NamespaceAsyncIOEventEmitter(NamespaceEventEmitter, AsyncIOEventEmitter):
+        pass
+
+    __all__.append("NamespaceAsyncIOEventEmitter")
+
+except ImportError:
+    pass
+
+try:
+    from pyee._twisted import TwistedEventEmitter  # noqa
+
+    class NamespaceTwistedEventEmitter(NamespaceEventEmitter, TwistedEventEmitter):
+        NAMESPACE_BLACKLIST = (*NamespaceEventEmitter.NAMESPACE_BLACKLIST, "failure")
+
+    __all__.append("NamespaceTwistedEventEmitter")
+except ImportError:
+    pass
+
+try:
+    from pyee._executor import ExecutorEventEmitter  # noqa
+
+    class NamespaceExecutorEventEmitter(NamespaceEventEmitter, ExecutorEventEmitter):
+        pass
+
+    __all__.append("NamespaceExecutorEventEmitter")
+except ImportError:
+    pass
+
+try:
+    from pyee._trio import TrioEventEmitter  # noqa
+
+    class NamespaceTrioEventEmitter(NamespaceEventEmitter, TrioEventEmitter):
+        pass
+
+    __all__.append("NamespaceTrioEventEmitter")
+except (ImportError, SyntaxError):
+    pass

--- a/pyee/namespace.py
+++ b/pyee/namespace.py
@@ -107,8 +107,7 @@ try:
     class NamespaceTwistedEventEmitter(
         NamespaceEventEmitter, TwistedEventEmitter
     ):
-        NAMESPACE_BLACKLIST = (
-            *NamespaceEventEmitter.NAMESPACE_BLACKLIST,
+        NAMESPACE_BLACKLIST = NamespaceEventEmitter.NAMESPACE_BLACKLIST + (
             "failure",
         )
 

--- a/pyee/namespace.py
+++ b/pyee/namespace.py
@@ -45,6 +45,9 @@ class NamespaceEventEmitter(BaseEventEmitter):
             error,
         )
 
+    def on(self, event, f=None):
+        return super().on(self._to_namespace(event), f)
+
     def emit(self, event, *args, **kwargs):
         return super().emit(self._to_namespace(event), *args, **kwargs)
 
@@ -68,7 +71,6 @@ try:
         pass
 
     __all__.append("NamespaceAsyncIOEventEmitter")
-
 except ImportError:
     pass
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,19 +1,25 @@
 # -*- coding: utf-8 -*-
 
+import pytest
 from mock import Mock
 from time import sleep
 
 from pyee import ExecutorEventEmitter
+from pyee.namespace import NamespaceExecutorEventEmitter
 
 
 class PyeeTestError(Exception):
     pass
 
 
-def test_executor_emit():
+@pytest.mark.parametrize('cls', [
+    ExecutorEventEmitter,
+    NamespaceExecutorEventEmitter
+])
+def test_executor_emit(cls):
     """Test that ExecutorEventEmitters can emit events.
     """
-    with ExecutorEventEmitter() as ee:
+    with cls() as ee:
         should_call = Mock()
 
         @ee.on('event')
@@ -26,10 +32,14 @@ def test_executor_emit():
         should_call.assert_called_once()
 
 
-def test_executor_once():
+@pytest.mark.parametrize('cls', [
+    ExecutorEventEmitter,
+    NamespaceExecutorEventEmitter
+])
+def test_executor_once(cls):
     """Test that ExecutorEventEmitters also emit events for once.
     """
-    with ExecutorEventEmitter() as ee:
+    with cls() as ee:
         should_call = Mock()
 
         @ee.once('event')
@@ -42,10 +52,14 @@ def test_executor_once():
         should_call.assert_called_once()
 
 
-def test_executor_error():
+@pytest.mark.parametrize('cls', [
+    ExecutorEventEmitter,
+    NamespaceExecutorEventEmitter
+])
+def test_executor_error(cls):
     """Test that ExecutorEventEmitters handle errors.
     """
-    with ExecutorEventEmitter() as ee:
+    with cls() as ee:
         should_call = Mock()
 
         @ee.on('event')

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from mock import Mock
 from pytest import raises
 
-from pyee.namespace import NamespaceEventEmitter
+from pyee.namespace import NamespaceEventEmitter, NamespaceBlacklistException
 
 
 class PyeeTestException(Exception):
@@ -13,61 +13,262 @@ class PyeeTestException(Exception):
 
 def test_emit_simple():
     ee = NamespaceEventEmitter()
-    call_me = Mock()
+    call_me1 = Mock()
+    call_me2 = Mock()
 
     # Register listener
-    ee.on('event', call_me)
+    ee.on("event", call_me1)
+    ee.on(("event",), call_me2)
 
-    ee.emit('event', 1, 2, 3, test="wow")
+    ee.emit("event", 1, 2, 3, test="so simple")
+    call_me1.assert_called_once_with(1, 2, 3, test="so simple")
+    call_me2.assert_called_once_with(1, 2, 3, test="so simple")
 
-    call_me.assert_called_with(1, 2, 3, test="wow")
+    for mock in (call_me1, call_me2):
+        mock.reset_mock()
 
-    ee.emit(('event',), 4, 5, 6, test="much")
-
-    call_me.assert_called_with(4, 5, 6, test="much")
-
-
-def test_emit_namespace_single_level():
-    ee = NamespaceEventEmitter()
-    call_me = Mock()
-
-    # Register listener
-    ee.on(('event', ), call_me)
-
-    ee.emit('event', 1, 2, 3, test="wow")
-
-    call_me.assert_called_with(1, 2, 3, test="wow")
-
-    ee.emit(('event',), 4, 5, 6, test="much")
-
-    call_me.assert_called_with(4, 5, 6, test="much")
+    ee.emit(("event",), 4, 5, 6, test="such ease")
+    call_me1.assert_called_once_with(4, 5, 6, test="such ease")
+    call_me2.assert_called_once_with(4, 5, 6, test="such ease")
 
 
 def test_emit_namespace_multi_level():
-    ee = NamespaceEventEmitter()
-    call_me = Mock()
-
-    # Register listener
-    ee.on(('event', 'level', 'type'), call_me)
-
-    ee.emit(('event', 'level', 'type'), 1, 2, 3, test="wow")
-
-    call_me.assert_called_with(1, 2, 3, test="wow")
-
-
-def test_listener_namespace_multi_level():
     ee = NamespaceEventEmitter()
     call_me1 = Mock()
     call_me2 = Mock()
     call_me3 = Mock()
 
     # Register listener
-    ee.on(('event', 'level'), call_me2)
-    ee.on(('event', 'level', 'type'), call_me3)
-    ee.on(('event',), call_me1)
+    ee.on(("event",), call_me1)
+    ee.on(("event", "level"), call_me2)
+    ee.on(("event", "level", "type"), call_me3)
 
-    ee.emit(('event', 'level', 'type'), 1, 2, 3, test="wow")
+    ee.emit(("event", "level", "type"), 1, 2, 3, test="wow")
 
-    call_me1.assert_called_with(1, 2, 3, test="wow")
-    call_me2.assert_called_with(1, 2, 3, test="wow")
-    call_me3.assert_called_with(1, 2, 3, test="wow")
+    call_me1.assert_called_once_with(1, 2, 3, test="wow")
+    call_me2.assert_called_once_with(1, 2, 3, test="wow")
+    call_me3.assert_called_once_with(1, 2, 3, test="wow")
+    for mock in (call_me1, call_me2, call_me3):
+        mock.reset_mock()
+
+    ee.emit(("event", "level"), 4, 5, 6, test="very namespaced")
+    call_me1.assert_called_once_with(4, 5, 6, test="very namespaced")
+    call_me2.assert_called_once_with(4, 5, 6, test="very namespaced")
+    call_me3.assert_not_called()
+    for mock in (call_me1, call_me2, call_me3):
+        mock.reset_mock()
+
+    ee.emit(("event",), 7, 8, 9, test="much separation")
+    call_me1.assert_called_once_with(7, 8, 9, test="much separation")
+    call_me2.assert_not_called()
+    call_me3.assert_not_called()
+
+
+def test_emit_simple_error():
+    ee = NamespaceEventEmitter()
+    call_me1 = Mock()
+    call_me2 = Mock()
+
+    test_exception1 = PyeeTestException()
+
+    with raises(PyeeTestException):
+        ee.emit("error", test_exception1)
+
+    with raises(PyeeTestException):
+        ee.emit(("error",), test_exception1)
+
+    ee.on("error", call_me1)
+    ee.on(("error",), call_me2)
+
+    # No longer raises and error instead return True indicating handled
+    assert ee.emit("error", test_exception1) is True
+
+    call_me1.assert_called_once_with(test_exception1)
+    call_me2.assert_called_once_with(test_exception1)
+    for mock in (call_me1, call_me2):
+        mock.reset_mock()
+
+    test_exception2 = RuntimeError()
+
+    # No longer raises and error instead return True indicating handled
+    assert ee.emit(("error",), test_exception2) is True
+
+    call_me1.assert_called_once_with(test_exception2)
+    call_me2.assert_called_once_with(test_exception2)
+
+
+def test_emit_namespace_error_multi_level():
+    ee = NamespaceEventEmitter()
+    call_me1 = Mock()
+    call_me2 = Mock()
+    call_me3 = Mock()
+
+    test_exception1 = PyeeTestException()
+
+    with raises(PyeeTestException):
+        ee.emit(("error", "level"), test_exception1)
+
+    with raises(PyeeTestException):
+        ee.emit(("error", "level", "type"), test_exception1)
+
+    ee.on(("error", "level", "type"), call_me3)
+
+    with raises(PyeeTestException):
+        ee.emit(("error", "level"), test_exception1)
+
+    with raises(PyeeTestException):
+        ee.emit(("error",), test_exception1)
+
+    ee.on(("error", "level"), call_me2)
+
+    with raises(PyeeTestException):
+        ee.emit(("error",), test_exception1)
+
+    # Register listener
+    ee.on(("error",), call_me1)
+
+    test_exception2 = RuntimeError("very error")
+
+    ee.emit(("error", "level", "type"), test_exception2)
+
+    call_me1.assert_called_once_with(test_exception2)
+    call_me2.assert_called_once_with(test_exception2)
+    call_me3.assert_called_once_with(test_exception2)
+    for mock in (call_me1, call_me2, call_me3):
+        mock.reset_mock()
+
+    test_exception3 = RuntimeError("oh god not")
+
+    ee.emit(("error", "level"), test_exception3)
+    call_me1.assert_called_once_with(test_exception3)
+    call_me2.assert_called_once_with(test_exception3)
+    call_me3.assert_not_called()
+    for mock in (call_me1, call_me2, call_me3):
+        mock.reset_mock()
+
+    test_exception4 = RuntimeError("help")
+
+    ee.emit(("error",), test_exception4)
+    call_me1.assert_called_once_with(test_exception4)
+    call_me2.assert_not_called()
+    call_me3.assert_not_called()
+
+
+def test_emit_return_specific_to_generic():
+    ee = NamespaceEventEmitter()
+    call_me = Mock()
+
+    assert not ee.emit("data")
+    assert not ee.emit(("data",))
+    assert not ee.emit(("data", "specific"))
+    assert not ee.emit(("data", "specific", "restricted"))
+
+    ee.on(("data", "specific", "restricted"), call_me)
+
+    assert not ee.emit("data")
+    assert not ee.emit(("data",))
+    assert not ee.emit(("data", "specific"))
+    assert ee.emit(("data", "specific", "restricted"))
+
+    ee.on(("data", "specific"), call_me)
+
+    assert not ee.emit("data")
+    assert not ee.emit(("data",))
+    assert ee.emit(("data", "specific"))
+    assert ee.emit(("data", "specific", "restricted"))
+
+    ee.on(("data",), call_me)
+
+    assert ee.emit("data")
+    assert ee.emit(("data",))
+    assert ee.emit(("data", "specific"))
+    assert ee.emit(("data", "specific", "restricted"))
+
+
+def test_emit_return_generic_to_specific():
+    ee = NamespaceEventEmitter()
+    call_me = Mock()
+
+    assert not ee.emit("data")
+    assert not ee.emit(("data",))
+    assert not ee.emit(("data", "specific"))
+    assert not ee.emit(("data", "specific", "restricted"))
+
+    ee.on("data", call_me)
+
+    assert ee.emit("data")
+    assert ee.emit(("data",))
+    assert ee.emit(("data", "specific"))
+    assert ee.emit(("data", "specific", "restricted"))
+
+
+def test_new_listener_event():
+    ee = NamespaceEventEmitter()
+    call_me = Mock()
+
+    with raises(NamespaceBlacklistException):
+        ee.on(("new_listener", "can't do that"), call_me)
+
+    ee.on("new_listener", call_me)
+
+    # Should fire new_listener event
+    @ee.on("event")
+    def event_handler(data):
+        pass
+
+    call_me.assert_called_once_with(("event",), event_handler)
+    call_me.reset_mock()
+
+    @ee.on(("event",))
+    def event_handler(data):
+        pass
+
+    call_me.assert_called_once_with(("event",), event_handler)
+    call_me.reset_mock()
+
+    @ee.on(("event", "namespace"))
+    def event_handler(data):
+        pass
+
+    call_me.assert_called_once_with(("event", "namespace"), event_handler)
+
+
+def test_listener_removal():
+    ee = NamespaceEventEmitter()
+
+    # Some functions to pass to the EE
+    def first():
+        return 1
+
+    ee.on(("event", "test"), first)
+
+    @ee.on(("event", "test"))
+    def second():
+        return 2
+
+    @ee.on(("event", "test"))
+    def third():
+        return 3
+
+    def fourth():
+        return 4
+
+    ee.on(("event", "test"), fourth)
+
+    assert ee._events[("event", "test")] == OrderedDict(
+        [(first, first), (second, second), (third, third), (fourth, fourth)]
+    )
+
+    ee.remove_listener(("event", "test"), second)
+
+    assert ee._events[("event", "test")] == OrderedDict(
+        [(first, first), (third, third), (fourth, fourth)]
+    )
+
+    ee.remove_listener(("event", "test"), first)
+    assert ee._events[("event", "test")] == OrderedDict(
+        [(third, third), (fourth, fourth)]
+    )
+
+    ee.remove_all_listeners(("event", "test"))
+    assert ee._events[("event", "test")] == OrderedDict()

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+from collections import OrderedDict
+
+from mock import Mock
+from pytest import raises
+
+from pyee.namespace import NamespaceEventEmitter
+
+
+class PyeeTestException(Exception):
+    pass
+
+
+def test_emit_simple():
+    ee = NamespaceEventEmitter()
+    call_me = Mock()
+
+    # Register listener
+    ee.on('event', call_me)
+
+    ee.emit('event', 1, 2, 3, test="wow")
+
+    call_me.assert_called_with(1, 2, 3, test="wow")
+
+    ee.emit(('event',), 4, 5, 6, test="much")
+
+    call_me.assert_called_with(4, 5, 6, test="much")
+
+
+def test_emit_namespace_single_level():
+    ee = NamespaceEventEmitter()
+    call_me = Mock()
+
+    # Register listener
+    ee.on(('event', ), call_me)
+
+    ee.emit('event', 1, 2, 3, test="wow")
+
+    call_me.assert_called_with(1, 2, 3, test="wow")
+
+    ee.emit(('event',), 4, 5, 6, test="much")
+
+    call_me.assert_called_with(4, 5, 6, test="much")
+
+
+def test_emit_namespace_multi_level():
+    ee = NamespaceEventEmitter()
+    call_me = Mock()
+
+    # Register listener
+    ee.on(('event', 'level', 'type'), call_me)
+
+    ee.emit(('event', 'level', 'type'), 1, 2, 3, test="wow")
+
+    call_me.assert_called_with(1, 2, 3, test="wow")
+
+
+def test_listener_namespace_multi_level():
+    ee = NamespaceEventEmitter()
+    call_me1 = Mock()
+    call_me2 = Mock()
+    call_me3 = Mock()
+
+    # Register listener
+    ee.on(('event', 'level'), call_me2)
+    ee.on(('event', 'level', 'type'), call_me3)
+    ee.on(('event',), call_me1)
+
+    ee.emit(('event', 'level', 'type'), 1, 2, 3, test="wow")
+
+    call_me1.assert_called_with(1, 2, 3, test="wow")
+    call_me2.assert_called_with(1, 2, 3, test="wow")
+    call_me3.assert_called_with(1, 2, 3, test="wow")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -8,6 +8,7 @@ from mock import Mock
 from pytest import raises
 
 from pyee import BaseEventEmitter, EventEmitter
+from pyee.namespace import NamespaceEventEmitter
 
 
 class PyeeTestException(Exception):
@@ -16,7 +17,8 @@ class PyeeTestException(Exception):
 
 @pytest.mark.parametrize('cls', [
     BaseEventEmitter,
-    EventEmitter
+    EventEmitter,
+    NamespaceEventEmitter
 ])
 def test_emit_sync(cls):
     """Basic synchronous emission works"""
@@ -37,7 +39,8 @@ def test_emit_sync(cls):
 
 @pytest.mark.parametrize('cls', [
     BaseEventEmitter,
-    EventEmitter
+    EventEmitter,
+    NamespaceEventEmitter
 ])
 def test_emit_error(cls):
     """Errors raise with no event handler, otherwise emit on handler"""
@@ -59,13 +62,17 @@ def test_emit_error(cls):
     call_me.assert_called_once()
 
 
-def test_emit_return():
+@pytest.mark.parametrize('cls', [
+    BaseEventEmitter,
+    NamespaceEventEmitter
+])
+def test_emit_return(cls):
     """Emit returns True when handlers are registered on an event, and false
     otherwise.
     """
 
     call_me = Mock()
-    ee = BaseEventEmitter()
+    ee = cls()
 
     # make sure emitting without a callback returns False
     assert not ee.emit('data')
@@ -78,7 +85,11 @@ def test_emit_return():
 
 
 def test_new_listener_event():
-    """The 'new_listener' event fires whenever a new listerner is added."""
+    """The 'new_listener' event fires whenever a new listener is added.
+
+    Don't test NamespaceEventEmitter here due to difference in behaviour.
+    A test specific for NamespaceEventEmitter is implemented in test_namespace.py
+    """
 
     call_me = Mock()
     ee = BaseEventEmitter()
@@ -94,7 +105,11 @@ def test_new_listener_event():
 
 
 def test_listener_removal():
-    """Removing listeners removes the correct listener from an event."""
+    """Removing listeners removes the correct listener from an event.
+
+    Don't test NamespaceEventEmitter here due to difference in behaviour.
+    A test specific for NamespaceEventEmitter is implemented in test_namespace.py
+    """
 
     ee = BaseEventEmitter()
 
@@ -142,13 +157,17 @@ def test_listener_removal():
     assert ee._events['event'] == OrderedDict()
 
 
-def test_listener_removal_on_emit():
+@pytest.mark.parametrize('cls', [
+    BaseEventEmitter,
+    NamespaceEventEmitter
+])
+def test_listener_removal_on_emit(cls):
     """Test that a listener removed during an emit is called inside the current
     emit cycle.
     """
 
     call_me = Mock()
-    ee = BaseEventEmitter()
+    ee = cls()
 
     def should_remove():
         ee.remove_listener('remove', call_me)
@@ -163,7 +182,7 @@ def test_listener_removal_on_emit():
     call_me.reset_mock()
 
     # Also test with the listeners added in the opposite order
-    ee = BaseEventEmitter()
+    ee = cls()
     ee.on('remove', call_me)
     ee.on('remove', should_remove)
 
@@ -172,7 +191,11 @@ def test_listener_removal_on_emit():
     call_me.assert_called_once()
 
 
-def test_once():
+@pytest.mark.parametrize('cls', [
+    BaseEventEmitter,
+    NamespaceEventEmitter
+])
+def test_once(cls):
     """Test that `once()` method works propers.
     """
 
@@ -180,7 +203,7 @@ def test_once():
     # gets removed afterwards
 
     call_me = Mock()
-    ee = BaseEventEmitter()
+    ee = cls()
 
     def once_handler(data):
         assert data == 'emitter is emitted!'
@@ -196,11 +219,15 @@ def test_once():
     assert ee._events['event'] == OrderedDict()
 
 
-def test_once_removal():
+@pytest.mark.parametrize('cls', [
+    BaseEventEmitter,
+    NamespaceEventEmitter
+])
+def test_once_removal(cls):
     """Removal of once functions works
     """
 
-    ee = BaseEventEmitter()
+    ee = cls()
 
     def once_handler(data):
         pass
@@ -214,11 +241,15 @@ def test_once_removal():
     assert ee._events['event'] == OrderedDict()
 
 
-def test_listeners():
+@pytest.mark.parametrize('cls', [
+    BaseEventEmitter,
+    NamespaceEventEmitter
+])
+def test_listeners(cls):
     """`listeners()` returns a copied list of listeners."""
 
     call_me = Mock()
-    ee = BaseEventEmitter()
+    ee = cls()
 
     @ee.on('event')
     def event_handler():
@@ -241,12 +272,16 @@ def test_listeners():
     call_me.assert_not_called()
 
 
-def test_properties_preserved():
+@pytest.mark.parametrize('cls', [
+    BaseEventEmitter,
+    NamespaceEventEmitter
+])
+def test_properties_preserved(cls):
     """Test that the properties of decorated functions are preserved."""
 
     call_me = Mock()
     call_me_also = Mock()
-    ee = BaseEventEmitter()
+    ee = cls()
 
     @ee.on('always')
     def always_event_handler():

--- a/tests/test_trio.py
+++ b/tests/test_trio.py
@@ -6,19 +6,24 @@ import pytest_trio.plugin  # noqa
 import trio
 
 from pyee import TrioEventEmitter
+from pyee.namespace import NamespaceTrioEventEmitter
 
 
 class PyeeTestError(Exception):
     pass
 
 
+@pytest.mark.parametrize('cls', [
+    TrioEventEmitter,
+    NamespaceTrioEventEmitter
+])
 @pytest.mark.trio
-async def test_trio_emit():
+async def test_trio_emit(cls):
     """Test that the trio event emitter can handle wrapping
     coroutines
     """
 
-    async with TrioEventEmitter() as ee:
+    async with cls() as ee:
 
         should_call = trio.Event()
 
@@ -36,13 +41,17 @@ async def test_trio_emit():
         assert result
 
 
+@pytest.mark.parametrize('cls', [
+    TrioEventEmitter,
+    NamespaceTrioEventEmitter
+])
 @pytest.mark.trio
-async def test_trio_once_emit():
+async def test_trio_once_emit(cls):
     """Test that trio event emitters also wrap coroutines when
     using once
     """
 
-    async with TrioEventEmitter() as ee:
+    async with cls() as ee:
         should_call = trio.Event()
 
         @ee.once('event')
@@ -59,13 +68,17 @@ async def test_trio_once_emit():
         assert result
 
 
+@pytest.mark.parametrize('cls', [
+    TrioEventEmitter,
+    NamespaceTrioEventEmitter
+])
 @pytest.mark.trio
-async def test_trio_error():
+async def test_trio_error(cls):
     """Test that trio event emitters can handle errors when
     wrapping coroutines
     """
 
-    async with TrioEventEmitter() as ee:
+    async with cls() as ee:
         send, rcv = trio.open_memory_channel(1)
 
         @ee.on('event')
@@ -87,12 +100,16 @@ async def test_trio_error():
         assert isinstance(result, PyeeTestError)
 
 
+@pytest.mark.parametrize('cls', [
+    TrioEventEmitter,
+    NamespaceTrioEventEmitter
+])
 @pytest.mark.trio
-async def test_sync_error(event_loop):
+async def test_sync_error(cls, event_loop):
     """Test that regular functions have the same error handling as coroutines
     """
 
-    async with TrioEventEmitter() as ee:
+    async with cls() as ee:
         send, rcv = trio.open_memory_channel(1)
 
         @ee.on('event')

--- a/tests/test_twisted.py
+++ b/tests/test_twisted.py
@@ -1,21 +1,26 @@
 # -*- coding: utf-8 -*-
 
+import pytest
 from mock import Mock
 from twisted.internet.defer import inlineCallbacks
 from twisted.python.failure import Failure
 
 from pyee import TwistedEventEmitter
+from pyee.namespace import NamespaceTwistedEventEmitter
 
 
 class PyeeTestError(Exception):
     pass
 
-
-def test_propagates_failure():
+@pytest.mark.parametrize('cls', [
+    TwistedEventEmitter,
+    NamespaceTwistedEventEmitter
+])
+def test_propagates_failure(cls):
     """Test that TwistedEventEmitters can propagate failures
     from twisted Deferreds
     """
-    ee = TwistedEventEmitter()
+    ee = cls()
 
     should_call = Mock()
 
@@ -34,11 +39,15 @@ def test_propagates_failure():
     should_call.assert_called_once()
 
 
-def test_propagates_sync_failure():
+@pytest.mark.parametrize('cls', [
+    TwistedEventEmitter,
+    NamespaceTwistedEventEmitter
+])
+def test_propagates_sync_failure(cls):
     """Test that TwistedEventEmitters can propagate failures
     from twisted Deferreds
     """
-    ee = TwistedEventEmitter()
+    ee = cls()
 
     should_call = Mock()
 
@@ -56,12 +65,16 @@ def test_propagates_sync_failure():
     should_call.assert_called_once()
 
 
-def test_propagates_exception():
+@pytest.mark.parametrize('cls', [
+    TwistedEventEmitter,
+    NamespaceTwistedEventEmitter
+])
+def test_propagates_exception(cls):
     """Test that TwistedEventEmitters propagate failures as exceptions to
     the error event when no failure handler
     """
 
-    ee = TwistedEventEmitter()
+    ee = cls()
 
     should_call = Mock()
 


### PR DESCRIPTION
Hello,

First off, thanks for the lib. I recently stumbled upon it and began using in some of my projects. It has worked like a charm. However, in the latest project I am working on, the need for namespaces in events has emerged. So, I decided to take a shot at implementing it.

I wanted to generate the least impact possible at the overall architecture of `BaseEventEmitter` while implementing this feature. So, what I ended up with was using tuples to represent namespaces and their levels. Basically I implemented a subclass: `NamespaceEventEmitter`, where `(emit|on|once|...)` receives a tuple that represents the namespaced event, instead of a string (It converts strings to single-element tuples for ease of use). Also, It has a modified `_call_handlers` method that calls all listeners in the namespace from the most generic level to the level the emitted event specified. Additionally, I implemented namespaced versions of each available emitter type. All the changes are self-contained to `pyee.namespace` as not to break any current behavior.

I implemented some tests and added the namespaced versions of each specific emitter to the tests they currently have implemented, everything is passing. However, I only ran them in python3.8, so some more testing is needed.

Solves https://github.com/jfhbrook/pyee/issues/47