### PR TITLE
Bump trio* deps

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -9,3 +9,4 @@ Listed in no particular order:
 - René Kijewski @Kijewski
 - Gabe Appleton @gappleto97
 - Daniel M. Capella @polyzen <polyzen@archlinux.org>
+- @decentral1se <hi@decentral1se>

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
     - pytest==5.2.4
     - pytest-asyncio==0.10.0
     - pytest-runner==4.4
-    - pytest-trio==0.5.2
+    - pytest-trio==0.6.0
     - mock==2.0.0
     - Sphinx==2.0.1
     - twine==1.13.0

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,6 @@ dependencies:
     - Sphinx==2.0.1
     - twine==1.13.0
     - tox==3.8.6
-    - trio==0.13.0
+    - trio==0.15.1
     - vcversioner==2.16.0.0
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,5 +9,5 @@ Sphinx==2.0.1
 twine==1.13.0
 Twisted==20.3.0
 tox==3.8.6
-trio==0.13.0
+trio==0.15.1
 vcversioner==2.16.0.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,7 +3,7 @@ flake8==3.7.7
 pytest==5.2.4
 pytest-asyncio==0.10.0
 pytest-runner==4.4
-pytest-trio==0.5.2
+pytest-trio==0.6.0
 mock==2.0.0
 Sphinx==2.0.1
 twine==1.13.0

--- a/requirements_dev_py35.txt
+++ b/requirements_dev_py35.txt
@@ -7,5 +7,5 @@ Sphinx==2.0.1
 twine==1.13.0
 Twisted==20.3.0
 tox==3.8.6
-trio==0.13.0
+trio==0.15.1
 vcversioner==2.16.0.0


### PR DESCRIPTION
Some dependency updates coming down the tubes...

```
➜  pyee (bump-trio) ✔ grep -iR "trio==" .
./requirements_dev.txt:pytest-trio==0.6.0
./requirements_dev.txt:trio==0.15.1
./requirements_dev_py35.txt:trio==0.15.1
./environment.yml:    - pytest-trio==0.6.0
./environment.yml:    - trio==0.15.1
```