### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     author="Joshua Holbrook",
     author_email="josh.holbrook@gmail.com",
     url="https://github.com/jfhbrook/pyee",
+    license="MIT",
     keywords=[
         "events", "emitter", "node.js", "node", "eventemitter",
         "event_emitter"


### PR DESCRIPTION
Add license tag to allow third-party tools, e.g., PyPI, to get the used license.