### PR TITLE
Drop Python 2.7 support and remove CompatEventEmitter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 sudo: false
 python:
+  - "3.5"
+  - "3.6"
   - "3.7"
   - "3.8"
 install:

--- a/pyee/__init__.py
+++ b/pyee/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
-pyee supplies a ``BaseEventEmitter`` class that is similar to the
+pyee supplies a ``EventEmitter`` class that is similar to the
 ``EventEmitter`` class from Node.js. In addition, it supplies the subclasses
 ``AsyncIOEventEmitter``, ``TwistedEventEmitter`` and ``ExecutorEventEmitter``
 for supporting async and threaded execution with asyncio, twisted, and
@@ -13,9 +13,9 @@ Example
 
 ::
 
-    In [1]: from pyee import BaseEventEmitter
+    In [1]: from pyee import EventEmitter
 
-    In [2]: ee = BaseEventEmitter()
+    In [2]: ee = EventEmitter()
 
     In [3]: @ee.on('event')
        ...: def event_handler():
@@ -29,11 +29,23 @@ Example
 
 """
 
+from warnings import warn
+
 from pyee._base import (
-    BaseEventEmitter,
+    EventEmitter,
     PyeeException
 )
-from pyee._compat import CompatEventEmitter as EventEmitter
+
+
+class BaseEventEmitter(EventEmitter):
+    def __init__(self):
+        warn(DeprecationWarning(
+            'pyee.BaseEventEmitter is deprecated and will be removed in a '
+            'future major version; you should instead use pyee.EventEmitter.'
+        ))
+
+        super(BaseEventEmitter, self).__init__()
+
 
 __all__ = ['BaseEventEmitter', 'EventEmitter', 'PyeeException']
 

--- a/pyee/_asyncio.py
+++ b/pyee/_asyncio.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 
 from asyncio import ensure_future, Future, iscoroutine
-from pyee._base import BaseEventEmitter
+from pyee._base import EventEmitter
 
 __all__ = ['AsyncIOEventEmitter']
 
 
-class AsyncIOEventEmitter(BaseEventEmitter):
+class AsyncIOEventEmitter(EventEmitter):
     """An event emitter class which can run asyncio coroutines in addition to
     synchronous blocking functions. For example::
 

--- a/pyee/_base.py
+++ b/pyee/_base.py
@@ -2,7 +2,7 @@
 
 from collections import defaultdict, OrderedDict
 
-__all__ = ['BaseEventEmitter', 'PyeeException']
+__all__ = ['EventEmitter', 'PyeeException']
 
 
 class PyeeException(Exception):
@@ -10,7 +10,7 @@ class PyeeException(Exception):
     pass
 
 
-class BaseEventEmitter(object):
+class EventEmitter:
     """The base event emitter class. All other event emitters inherit from
     this class.
 

--- a/pyee/_executor.py
+++ b/pyee/_executor.py
@@ -2,10 +2,7 @@
 
 from pyee._base import BaseEventEmitter
 
-try:
-    from concurrent.futures import ThreadPoolExecutor
-except ImportError:
-    from futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 
 __all__ = ['ExecutorEventEmitter']
 

--- a/pyee/_executor.py
+++ b/pyee/_executor.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from pyee._base import BaseEventEmitter
+from pyee._base import EventEmitter
 
 from concurrent.futures import ThreadPoolExecutor
 
 __all__ = ['ExecutorEventEmitter']
 
 
-class ExecutorEventEmitter(BaseEventEmitter):
+class ExecutorEventEmitter(EventEmitter):
     """An event emitter class which runs handlers in a ``concurrent.futures``
     executor. If using python 2, this will fall back to trying to use the
     ``futures`` backported library (caveats there apply).

--- a/pyee/_trio.py
+++ b/pyee/_trio.py
@@ -2,12 +2,12 @@
 
 from contextlib import asynccontextmanager
 import trio
-from pyee._base import BaseEventEmitter, PyeeException
+from pyee._base import EventEmitter, PyeeException
 
 __all__ = ['TrioEventEmitter']
 
 
-class TrioEventEmitter(BaseEventEmitter):
+class TrioEventEmitter(EventEmitter):
     """An event emitter class which can run trio tasks in a trio nursery.
 
     By default, this class will lazily create both a nursery manager (the

--- a/pyee/_twisted.py
+++ b/pyee/_twisted.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from pyee._base import BaseEventEmitter
+from pyee._base import EventEmitter
 
 from twisted.internet.defer import Deferred, ensureDeferred
 from twisted.python.failure import Failure
@@ -14,7 +14,7 @@ except ImportError:
 __all__ = ['TwistedEventEmitter']
 
 
-class TwistedEventEmitter(BaseEventEmitter):
+class TwistedEventEmitter(EventEmitter):
     """An event emitter class which can run twisted coroutines and handle
     returned Deferreds, in addition to synchronous blocking functions. For
     example::

--- a/setup.py
+++ b/setup.py
@@ -14,19 +14,12 @@ setup(
 
     packages=find_packages(),
     tests_require=[
-        'attrs == 19.3.0; python_version < "3.0"',
-        'futures; python_version < "3.0"',
-        'mock; python_version >= "3.6"',
-        'mock == 3.0.5; python_version < "3.6"',
-        'pyhamcrest == 1.10.1; python_version < "3.5"',
-        'pyparsing == 2.4.7; python_version < "3.0"',
-        'pytest; python_version > "3.4"',
-        'pytest == 4.6.11; python_version <= "3.4"',
+        'mock',
+        'pytest',
         'pytest-asyncio; python_version >= "3.4"',
         'pytest-trio; python_version >= "3.7"',
         'trio; python_version > "3.6"',
-        'twisted',
-        'zipp == 3.0.0; python_version < "3.0"'
+        'twisted'
     ],
     setup_requires=[
         'pytest-runner',

--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -12,26 +12,22 @@ except ImportError:
 
 from mock import Mock
 
-from twisted.internet.defer import ensureDeferred, succeed
+from twisted.internet.defer import succeed
 
-from pyee import EventEmitter, AsyncIOEventEmitter, TwistedEventEmitter
+from pyee import AsyncIOEventEmitter, TwistedEventEmitter
 
 
 class PyeeTestError(Exception):
     pass
 
 
-@pytest.mark.parametrize('cls', [
-    AsyncIOEventEmitter,
-    EventEmitter
-])
 @pytest.mark.asyncio
-async def test_asyncio_emit(cls, event_loop):
-    """Test that asyncio-supporting event emitters can handle wrapping
+async def test_asyncio_emit(event_loop):
+    """Test that AsyncIOEventEmitter can handle wrapping
     coroutines
     """
 
-    ee = cls(loop=event_loop)
+    ee = AsyncIOEventEmitter(loop=event_loop)
 
     should_call = Future(loop=event_loop)
 
@@ -46,17 +42,13 @@ async def test_asyncio_emit(cls, event_loop):
     assert result is True
 
 
-@pytest.mark.parametrize('cls', [
-    AsyncIOEventEmitter,
-    EventEmitter
-])
 @pytest.mark.asyncio
-async def test_asyncio_once_emit(cls, event_loop):
-    """Test that asyncio-supporting event emitters also wrap coroutines when
+async def test_asyncio_once_emit(event_loop):
+    """Test that AsyncIOEventEmitter also wrap coroutines when
     using once
     """
 
-    ee = cls(loop=event_loop)
+    ee = AsyncIOEventEmitter(loop=event_loop)
 
     should_call = Future(loop=event_loop)
 
@@ -71,16 +63,12 @@ async def test_asyncio_once_emit(cls, event_loop):
     assert result is True
 
 
-@pytest.mark.parametrize('cls', [
-    AsyncIOEventEmitter,
-    EventEmitter
-])
 @pytest.mark.asyncio
-async def test_asyncio_error(cls, event_loop):
-    """Test that asyncio-supporting event emitters can handle errors when
+async def test_asyncio_error(event_loop):
+    """Test that AsyncIOEventEmitter can handle errors when
     wrapping coroutines
     """
-    ee = cls(loop=event_loop)
+    ee = AsyncIOEventEmitter(loop=event_loop)
 
     should_call = Future(loop=event_loop)
 
@@ -149,15 +137,11 @@ async def test_sync_error(event_loop):
     assert isinstance(result, PyeeTestError)
 
 
-@pytest.mark.parametrize('cls,kwargs', [
-    (TwistedEventEmitter, dict()),
-    (EventEmitter, dict(scheduler=ensureDeferred))
-])
-def test_twisted_emit(cls, kwargs):
-    """Test that twisted-supporting event emitters can handle wrapping
+def test_twisted_emit():
+    """Test that TwistedEventEmitter can handle wrapping
     coroutines
     """
-    ee = cls(**kwargs)
+    ee = TwistedEventEmitter()
 
     should_call = Mock()
 
@@ -171,15 +155,11 @@ def test_twisted_emit(cls, kwargs):
     should_call.assert_called_once()
 
 
-@pytest.mark.parametrize('cls,kwargs', [
-    (TwistedEventEmitter, dict()),
-    (EventEmitter, dict(scheduler=ensureDeferred))
-])
-def test_twisted_once(cls, kwargs):
-    """Test that twisted-supporting event emitters also wrap coroutines for
+def test_twisted_once():
+    """Test that TwistedEventEmitter also wraps coroutines for
     once
     """
-    ee = cls(**kwargs)
+    ee = TwistedEventEmitter()
 
     should_call = Mock()
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,28 +1,21 @@
 # -*- coding: utf-8 -*-
-import pytest
-
-from inspect import getmro
 from collections import OrderedDict
 
 from mock import Mock
 from pytest import raises
 
-from pyee import BaseEventEmitter, EventEmitter
+from pyee import EventEmitter
 
 
 class PyeeTestException(Exception):
     pass
 
 
-@pytest.mark.parametrize('cls', [
-    BaseEventEmitter,
-    EventEmitter
-])
-def test_emit_sync(cls):
+def test_emit_sync():
     """Basic synchronous emission works"""
 
     call_me = Mock()
-    ee = cls()
+    ee = EventEmitter()
 
     @ee.on('event')
     def event_handler(data, **kwargs):
@@ -35,15 +28,11 @@ def test_emit_sync(cls):
     call_me.assert_called_once()
 
 
-@pytest.mark.parametrize('cls', [
-    BaseEventEmitter,
-    EventEmitter
-])
-def test_emit_error(cls):
+def test_emit_error():
     """Errors raise with no event handler, otherwise emit on handler"""
 
     call_me = Mock()
-    ee = cls()
+    ee = EventEmitter()
 
     test_exception = PyeeTestException('lololol')
 
@@ -65,7 +54,7 @@ def test_emit_return():
     """
 
     call_me = Mock()
-    ee = BaseEventEmitter()
+    ee = EventEmitter()
 
     # make sure emitting without a callback returns False
     assert not ee.emit('data')
@@ -81,7 +70,7 @@ def test_new_listener_event():
     """The 'new_listener' event fires whenever a new listerner is added."""
 
     call_me = Mock()
-    ee = BaseEventEmitter()
+    ee = EventEmitter()
 
     ee.on('new_listener', call_me)
 
@@ -96,7 +85,7 @@ def test_new_listener_event():
 def test_listener_removal():
     """Removing listeners removes the correct listener from an event."""
 
-    ee = BaseEventEmitter()
+    ee = EventEmitter()
 
     # Some functions to pass to the EE
     def first():
@@ -148,7 +137,7 @@ def test_listener_removal_on_emit():
     """
 
     call_me = Mock()
-    ee = BaseEventEmitter()
+    ee = EventEmitter()
 
     def should_remove():
         ee.remove_listener('remove', call_me)
@@ -163,7 +152,7 @@ def test_listener_removal_on_emit():
     call_me.reset_mock()
 
     # Also test with the listeners added in the opposite order
-    ee = BaseEventEmitter()
+    ee = EventEmitter()
     ee.on('remove', call_me)
     ee.on('remove', should_remove)
 
@@ -180,7 +169,7 @@ def test_once():
     # gets removed afterwards
 
     call_me = Mock()
-    ee = BaseEventEmitter()
+    ee = EventEmitter()
 
     def once_handler(data):
         assert data == 'emitter is emitted!'
@@ -200,7 +189,7 @@ def test_once_removal():
     """Removal of once functions works
     """
 
-    ee = BaseEventEmitter()
+    ee = EventEmitter()
 
     def once_handler(data):
         pass
@@ -218,7 +207,7 @@ def test_listeners():
     """`listeners()` returns a copied list of listeners."""
 
     call_me = Mock()
-    ee = BaseEventEmitter()
+    ee = EventEmitter()
 
     @ee.on('event')
     def event_handler():
@@ -246,7 +235,7 @@ def test_properties_preserved():
 
     call_me = Mock()
     call_me_also = Mock()
-    ee = BaseEventEmitter()
+    ee = EventEmitter()
 
     @ee.on('always')
     def always_event_handler():
@@ -272,36 +261,3 @@ def test_properties_preserved():
     # Calling the event handler directly doesn't clear the handler
     ee.emit('once')
     call_me_also.assert_called_once()
-
-
-def test_inheritance():
-    """Test that inheritance is preserved from object"""
-    assert object in getmro(BaseEventEmitter)
-
-    class example(BaseEventEmitter):
-        def __init__(self):
-            super(example, self).__init__()
-
-    assert BaseEventEmitter in getmro(example)
-    assert object in getmro(example)
-
-
-def test_multiple_inheritance():
-    """Test that inheritance is preserved along a lengthy MRO"""
-    class example(BaseEventEmitter):
-        def __init__(self):
-            super(example, self).__init__()
-
-    class _example(example):
-        def __init__(self):
-            super(_example, self).__init__()
-
-    class example2(_example):
-        def __init__(self):
-            super(example2, self).__init__()
-
-    class _example2(_example):
-        def __init__(self):
-            super(_example2, self).__init__()
-
-    a = _example2()  # noqa

--- a/tests/test_uplift.py
+++ b/tests/test_uplift.py
@@ -3,18 +3,18 @@
 import pytest
 
 from mock import call, Mock
-from pyee import BaseEventEmitter
+from pyee import EventEmitter
 from pyee.uplift import uplift
 
 
-class UpliftedEventEmitter(BaseEventEmitter):
+class UpliftedEventEmitter(EventEmitter):
     pass
 
 
 def test_uplift_emit():
     call_me = Mock()
 
-    base_ee = BaseEventEmitter()
+    base_ee = EventEmitter()
 
     @base_ee.on('base_event')
     def base_handler():
@@ -98,7 +98,7 @@ def test_uplift_emit():
   'new', 'underlying', 'neither'
 ])
 def test_exception_handling(error_handling):
-    base_ee = BaseEventEmitter()
+    base_ee = EventEmitter()
     uplifted_ee = uplift(
         UpliftedEventEmitter, base_ee,
         error_handling=error_handling
@@ -147,7 +147,7 @@ def test_exception_handling(error_handling):
 def test_proxy_new_listener(proxy_new_listener):
     call_me = Mock()
 
-    base_ee = BaseEventEmitter()
+    base_ee = EventEmitter()
 
     uplifted_ee = uplift(
         UpliftedEventEmitter,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py38
+envlist = py38
 
 [testenv]
 commands =


### PR DESCRIPTION
Cutting a major version that removes 2.7 support and also removes CompatEventEmitter. Given now #74 went it's definitely time, and if I'm doing a major bump anyway it makes sense to drop the old compatibility mode and get the EventEmitter name back. This also deprecates BaseEventEmitter.