### PR TITLE
Adding Power support(ppc64le) with continuous integration/testing to the project stays architecture independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+arch:
+  - amd64
+  - ppc64le
 sudo: false
 python:
   - "3.5"


### PR DESCRIPTION
I am working for IBM to port cpu arch ppc64le for open sources , As a part of continuous integration on this package, We have applied changes , This helps us simplify testing later when distributions are re-building and re-releasing, We typically build applications for customers and ISVs, and while we don't use this package directly,

Please help to verify and merge.

we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model,For more info tag @gerrith3.