### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pyee/_base.py
+++ b/pyee/_base.py
@@ -24,7 +24,7 @@ class EventEmitter:
       this event do not fire upon their own creation.
 
     - ``error``: When emitted raises an Exception by default, behavior can be
-      overriden by attaching callback to the event.
+      overridden by attaching callback to the event.
 
       For example::
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -67,7 +67,7 @@ def test_emit_return():
 
 
 def test_new_listener_event():
-    """The 'new_listener' event fires whenever a new listerner is added."""
+    """The 'new_listener' event fires whenever a new listener is added."""
 
     call_me = Mock()
     ee = EventEmitter()

--- a/tests/test_uplift.py
+++ b/tests/test_uplift.py
@@ -102,7 +102,7 @@ def test_exception_handling(error_handling):
     base_ee = EventEmitter()
     uplifted_ee = uplift(UpliftedEventEmitter, base_ee, error_handling=error_handling)
 
-    # Exception handling alwyas prefers uplifted
+    # Exception handling always prefers uplifted
     base_error = Exception("base error")
     uplifted_error = Exception("uplifted error")
 


### PR DESCRIPTION
There are small typos in:
- pyee/_base.py
- tests/test_sync.py
- tests/test_uplift.py

Fixes:
- Should read `listener` rather than `listerner`.
- Should read `always` rather than `alwyas`.
- Should read `overridden` rather than `overriden`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md