### PR TITLE
fix: EventEmitter.listeners() should not throw on unknown listeners

### DIFF
--- a/pyee/base.py
+++ b/pyee/base.py
@@ -226,4 +226,4 @@ class EventEmitter:
 
     def listeners(self, event: str) -> List[Callable]:
         """Returns a list of all listeners registered to the ``event``."""
-        return list(self._events[event].keys())
+        return list(self._events.get(event, OrderedDict()).keys())

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -240,6 +240,13 @@ def test_listeners():
     call_me.assert_not_called()
 
 
+def test_listeners_does_work_with_unknown_listeners():
+    """`listeners()` should not throw."""
+    ee = EventEmitter()
+    listeners = ee.listeners("event")
+    assert listeners == []
+
+
 def test_properties_preserved():
     """Test that the properties of decorated functions are preserved."""
 


### PR DESCRIPTION
Fixes #103