### PR TITLE
Add py.typed to MANIFEST.in file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,5 @@ include CHANGELOG.rst
 include CONTRIBUTORS.rst
 include DEVELOPMENT.rst
 include version.txt
+include pyee/py.typed
 recursive-include tests *.py


### PR DESCRIPTION
This commit adds the `py.typed` file to the `MANIFEST.in` file, ensuring compliance with PEP 561. This will allow the types to be seen from mypy when importing the package in a third party codebase.