### PR TITLE
Explicitly store AsyncIO Futures in a set

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+2023/06/08 Version 9.1.1
+------------------------
+
+- Store AsyncIO Futures in a set
+
 2023/04/30 Version 9.1.0
 ------------------------
 - ``EventEmitter`` supports pickling

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(README_rst, "r") as f:
 
 setup(
     name="pyee",
-    version="9.1.0",
+    version="9.1.1",
     packages=find_packages(),
     include_package_data=True,
     description="A port of node.js's EventEmitter to python.",

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -41,6 +41,7 @@ async def test_asyncio_emit(event_loop):
     result = await wait_for(should_call, 0.1)
 
     assert result is True
+    assert len(ee._waiting) == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #120.

I'm still not entirely convinced this is necessary, but the overhead is minimal and tests are still passing so I'm OK with it.