### PR TITLE
chore: minimum Python version fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 pyee supplies a `EventEmitter` object that is similar to the
 `EventEmitter` class from Node.js. It also supplies a number of subclasses
 with added support for async and threaded programming in python, such as
-async/await as seen in python 3.5+.
+async/await.
 
 ## Docs
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 pyee is a rough port of
 [node.js's EventEmitter](https://nodejs.org/api/events.html). Unlike its
 namesake, it includes a number of subclasses useful for implementing async
-and threaded programming in python, such as async/await as seen in python 3.5+.
+and threaded programming in python, such as async/await.
 
 ## Install
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,13 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Other/Nonlisted Topic",
 ]
+requires-python = ">=3.8"
 
 dependencies = [
     "typing-extensions"


### PR DESCRIPTION
Hi!

The mentioning of Python 3.5 in the readme was confusing, see https://github.com/conda-forge/pyee-feedstock/pull/23#discussion_r1233394781. So I think the best is to remove it.

This patch fixes also the classifiers and adds requires-python into the pyproject.yaml file.