### PR TITLE
QA: Add Python 3.11 to matrix

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
https://github.com/jfhbrook/pyee/blob/e820e6a27bc9eedc9cb92299df402e1354c69c55/pyproject.toml#L26

`classifiers` of this package indicate that this is compatible with Python 3.11.
Therefore, I make CI `QA` work with Python 3.11.