### PR TITLE
QA: Use Node.js LTS

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Node.js LTS
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: "lts/*"
       - name: Install the world
         run: |
           python -m pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
https://github.com/jfhbrook/pyee/blob/aa39fd2746e8ea0377ab56d6cc919d698bde6feb/.github/workflows/qa.yaml#L20

Because `name` says Node.js LTS is used, I specify the actual version accordingly.