### PR TITLE
QA: Automatically make python-version

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -5,12 +5,26 @@ on:
   pull_request:
     branches: [ "main" ]
 jobs:
+  make-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.make-versions.outputs.versions }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Make versions
+        id: make-versions
+        run: |
+          classifiers="$(yq -p toml -o toml '.project.classifiers[]' pyproject.toml | grep "Programming Language :: Python :: " | grep "\.")"
+          versions="$(echo "$classifiers" | sed -e 's/Programming Language :: Python :: \([0-9.]*\)$/"\1"/g' | tr '\n' ',' | sed -e 's/,$//g')"
+          echo "versions=[$versions]" > "$GITHUB_OUTPUT"
+
   qa:
     name: Run QA checks
     runs-on: ubuntu-latest
+    needs: make-versions
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ${{fromJson(needs.make-versions.outputs.versions)}}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Other/Nonlisted Topic",
 ]
 requires-python = ">=3.8"


### PR DESCRIPTION
I add a CI that puts Python versions listed in `project.classifiers` in `pyproject.yaml` into CI `QA`'s `python-version`.