### PR TITLE
Additional error context with UnhandledError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+- Add `PyeeError` which inherits from `PyeeException`
+- Raise `PyeeError` instead of `PyeeException` throughout
+- Raise `PyeeError` with emitted error as context in `EventEmitter` - this
+  ensures that there's a stack trace pointing at the code path inside the
+  `EventEmitter` which raises the error
+
 ## 2023/11/23 Version 11.1.0
 
 - Generate a man page with Sphinx (in addition to mkdocs HTML)

--- a/pyee/__init__.py
+++ b/pyee/__init__.py
@@ -30,7 +30,7 @@ In [5]:
 from warnings import warn
 
 from pyee.base import EventEmitter as EventEmitter
-from pyee.base import PyeeError, PyeeException
+from pyee.base import PyeeError, PyeeException, UnhandledError
 
 
 class BaseEventEmitter(EventEmitter):
@@ -49,7 +49,13 @@ class BaseEventEmitter(EventEmitter):
         super(BaseEventEmitter, self).__init__()
 
 
-__all__ = ["BaseEventEmitter", "EventEmitter", "PyeeException"]
+__all__ = [
+    "BaseEventEmitter",
+    "EventEmitter",
+    "PyeeException",
+    "PyeeError",
+    "UnhandledError",
+]
 
 try:
     from pyee.asyncio import AsyncIOEventEmitter as _AsyncIOEventEmitter  # noqa

--- a/pyee/__init__.py
+++ b/pyee/__init__.py
@@ -30,7 +30,7 @@ In [5]:
 from warnings import warn
 
 from pyee.base import EventEmitter as EventEmitter
-from pyee.base import PyeeException
+from pyee.base import PyeeError, PyeeException
 
 
 class BaseEventEmitter(EventEmitter):

--- a/pyee/base.py
+++ b/pyee/base.py
@@ -27,6 +27,22 @@ class PyeeError(PyeeException):
 Handler = TypeVar("Handler", bound=Callable)
 
 
+class UnhandledError(PyeeError):
+    """An unhandled error raised by an EventEmitter."""
+
+    def __init__(
+        self,
+        message: str,
+        f: Optional[Handler],
+        args: Optional[Tuple[Any]],
+        kwargs: Optional[Dict[str, Any]],
+    ):
+        super(UnhandledError, self).__init__(message)
+        self.__f__ = f
+        self.__args__ = args
+        self.__kwargs__ = kwargs
+
+
 class EventEmitter:
     """The base event emitter class. All other event emitters inherit from
     this class.

--- a/pyee/base.py
+++ b/pyee/base.py
@@ -38,8 +38,9 @@ class EventEmitter:
     - `new_listener`: Fires whenever a new listener is created. Listeners for
       this event do not fire upon their own creation.
 
-    - `error`: When emitted raises an Exception by default, behavior can be
-      overridden by attaching callback to the event.
+    - `error`: When emitted raises a PyeeError with the supplied error as
+      context by default, behavior can be overridden by attaching callback to
+      the event.
 
       For example:
 

--- a/pyee/base.py
+++ b/pyee/base.py
@@ -20,6 +20,10 @@ class PyeeException(Exception):
     """An exception internal to pyee."""
 
 
+class PyeeError(PyeeException):
+    """An error raised by pyee."""
+
+
 Handler = TypeVar("Handler", bound=Callable)
 
 
@@ -166,9 +170,9 @@ class EventEmitter:
     def _emit_handle_potential_error(self, event: str, error: Any) -> None:
         if event == "error":
             if isinstance(error, Exception):
-                raise error
+                raise PyeeError(f"Uncaught 'error' event: {error}") from error
             else:
-                raise PyeeException(f"Uncaught, unspecified 'error' event: {error}")
+                raise PyeeError(f"Uncaught, unspecified 'error' event: {error}")
 
     def _call_handlers(
         self,

--- a/pyee/executor.py
+++ b/pyee/executor.py
@@ -60,8 +60,8 @@ class ExecutorEventEmitter(EventEmitter):
         future: Future = self._executor.submit(f, *args, **kwargs)
 
         @future.add_done_callback
-        def _callback(f: Future) -> None:
-            exc: Optional[BaseException] = f.exception()
+        def _callback(fut: Future) -> None:
+            exc: Optional[BaseException] = fut.exception()
             if isinstance(exc, Exception):
                 self.emit("error", exc)
             elif exc is not None:

--- a/pyee/trio.py
+++ b/pyee/trio.py
@@ -6,7 +6,7 @@ from typing import Any, AsyncGenerator, Awaitable, Callable, Dict, Optional, Tup
 
 import trio
 
-from pyee.base import EventEmitter, PyeeException
+from pyee.base import EventEmitter, PyeeError
 
 __all__ = ["TrioEventEmitter"]
 
@@ -59,7 +59,7 @@ class TrioEventEmitter(EventEmitter):
         self._manager: Optional["AbstractAsyncContextManager[trio.Nursery]"] = None
         if nursery:
             if manager:
-                raise PyeeException(
+                raise PyeeError(
                     "You may either pass a nursery or a nursery manager " "but not both"
                 )
             self._nursery = nursery
@@ -89,7 +89,7 @@ class TrioEventEmitter(EventEmitter):
         kwargs: Dict[str, Any],
     ) -> None:
         if not self._nursery:
-            raise PyeeException("Uninitialized trio nursery")
+            raise PyeeError("Uninitialized trio nursery")
         self._nursery.start_soon(self._async_runner(f, args, kwargs))
 
     @asynccontextmanager
@@ -108,7 +108,7 @@ class TrioEventEmitter(EventEmitter):
                 self._nursery = nursery
                 yield self
         else:
-            raise PyeeException("Uninitialized nursery or nursery manager")
+            raise PyeeError("Uninitialized nursery or nursery manager")
 
     async def __aenter__(self) -> "TrioEventEmitter":
         self._context: Optional[
@@ -123,7 +123,7 @@ class TrioEventEmitter(EventEmitter):
         traceback: Optional[TracebackType],
     ) -> Optional[bool]:
         if self._context is None:
-            raise PyeeException("Attempting to exit uninitialized context")
+            raise PyeeError("Attempting to exit uninitialized context")
         rv = await self._context.__aexit__(type, value, traceback)
         self._context = None
         self._nursery = None

--- a/pyee/twisted.py
+++ b/pyee/twisted.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, Optional, Tuple
 from twisted.internet.defer import Deferred, ensureDeferred
 from twisted.python.failure import Failure
 
-from pyee.base import EventEmitter, PyeeException
+from pyee.base import EventEmitter, PyeeError
 
 try:
     from asyncio import iscoroutine
@@ -90,7 +90,7 @@ class TwistedEventEmitter(EventEmitter):
             elif isinstance(error, Exception):
                 self.emit("error", error)
             else:
-                self.emit("error", PyeeException(f"Unexpected failure object: {error}"))
+                self.emit("error", PyeeError(f"Unexpected failure object: {error}"))
         else:
             (super(TwistedEventEmitter, self))._emit_handle_potential_error(
                 event, error

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 from pytest import raises
 
-from pyee import EventEmitter
+from pyee import EventEmitter, PyeeError
 
 
 class PyeeTestException(Exception):
@@ -39,7 +39,7 @@ def test_emit_error():
 
     test_exception = PyeeTestException("lololol")
 
-    with raises(PyeeTestException):
+    with raises(PyeeError):
         ee.emit("error", test_exception)
 
     @ee.on("error")

--- a/tests/test_trio.py
+++ b/tests/test_trio.py
@@ -4,6 +4,7 @@ import pytest
 import pytest_trio.plugin  # noqa
 import trio
 
+from pyee import UnhandledError
 from pyee.trio import TrioEventEmitter
 
 
@@ -82,7 +83,11 @@ async def test_trio_error():
             async with rcv:
                 result = await rcv.__anext__()
 
-        assert isinstance(result, PyeeTestError)
+        assert isinstance(result, UnhandledError)
+        assert isinstance(result.__context__, PyeeTestError)
+        assert result.__f__ == event_handler
+        assert result.__args__ == tuple()
+        assert result.__kwargs__ == dict()
 
 
 @pytest.mark.trio
@@ -108,4 +113,8 @@ async def test_sync_error(event_loop):
             async with rcv:
                 result = await rcv.__anext__()
 
-        assert isinstance(result, PyeeTestError)
+        assert isinstance(result, UnhandledError)
+        assert isinstance(result.__context__, PyeeTestError)
+        assert result.__f__ == sync_handler
+        assert result.__args__ == tuple()
+        assert result.__kwargs__ == dict()


### PR DESCRIPTION
This PR creates a new error called an `UnhandledError`, which wraps errors going through pyee's internal error handling code. This error has additional context properties:

* __`f__` - the function the raising handler was called with
* `__args__` - the args the raising handler was called with
* `__kwargs__` - the kwargs the raising handler was called with

Making this work is a bit of a challenge. The interface for the `error` event handler (`Callable[[Any], Any]`) doesn't allow for passing extra args and kwargs, so I can't attach them to arbitrary error events. The best I can do is manually wrap raised exceptions in an `UnhandledError` in `_call_handlers` implementations. The upshot is that this is doable for exceptions raised in asyncio, trio and executors, but not in the base EventEmitter. Twisted also has some challenges, because of the way it sends failures through the "failure" event.

The twisted event emitter could be refactored to better support this context, but the base EventEmitter is DOA as far as that goes. This is probably OK, since the base EventEmitter has extremely naive error handling as compared to the other subclasses.

Now that I'm not entirely happy with this implementation:

* The limitations with emitting "raw" errors and the inability to attach context in the base and twisted EEs make for a wildly inconsistent experience
* it's a massive breaking change to the error handling code - you'd now have to catch an UnhandledError instead of the original exception
* I'm not sure UnhandledError is the right semantics. Are the errors really unhandled? (this is probably easy to fix by renaming it EventEmitterError)

Tests are passing, though the executor tests could use better coverage.

See also #142, which removes deprecated APIs and introduces a `PyeeError` - this PR is structured based on the assumption that this change goes through.

This is intended to close #102.