### PR TITLE
Fix release action

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -55,4 +55,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run actionlint
-        uses: raven-actions/actionlint@v1
+        uses: raven-actions/actionlint@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,6 +52,14 @@ jobs:
         with:
           name: man-page
           path: _build/man
+      - name: Build Release Notes
+        # thanks to https://gist.github.com/Integralist/57accaf446cf3e7974cd01d57158532c
+        run: awk '/^##/ {block++} {if (block == 1) { print }}' CHANGELOG.md > RELEASE_NOTES.md
+      - name: Store Release Notes
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-notes
+          path: RELEASE_NOTES.md
 
   pypi-release:
     runs-on: ubuntu-latest
@@ -87,19 +95,14 @@ jobs:
         with:
           name: man-page
           path: man
-      - name: Create a GitHub release
-        uses: comnoco/create-release-action@v2
-        env:
-          GITHUB_TOKEN: ${{ github.TOKEN }}
+      - name: Download release notes
+        uses: actions/download-artifact@v3
         with:
-          draft: false
-          prerelease: false
-          tag_name: ${{ github.ref }}
-          release_name: Release v${{ needs.versions.outputs.release-version }}
-      - name: Upload files to GitHub release
+          name: release-notes
+          path: RELEASE_NOTES.md
+      - name: Create a GitHub release
         env:
           GITHUB_TOKEN: ${{ github.TOKEN }}
         shell: bash
         run: |
-          cd '${{ github.workspace }}'
-          gh release upload '${{ github.ref }}' dist/* man/pyee.1
+          gh release create '${{ github.ref }}' --title 'Release v${{ needs.versions.outputs.release-version }}' --notes "$(cat RELEASE_NOTES.md)" dist/* man/pyee.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,12 +88,18 @@ jobs:
           name: man-page
           path: man
       - name: Create a GitHub release
-        uses: marvinpinto/action-automatic-releases@latest
+        uses: comnoco/create-release-action@v2
+        env:
+          GITHUB_TOKEN: ${{ github.TOKEN }}
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
           draft: false
           prerelease: false
-          title: Release v${{ needs.versions.outputs.release-version }}
-          files: |
-            dist/*
-            man/pyee.1
+          tag_name: ${{ github.ref }}
+          release_name: Release v${{ needs.versions.outputs.release-version }}
+      - name: Upload files to GitHub release
+        env:
+          GITHUB_TOKEN: ${{ github.TOKEN }}
+        shell: bash
+        run: |
+          cd '${{ github.workspace }}'
+          gh release upload '${{ github.ref }}' dist/* man/pyee.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2024/08/30 Version 11.1.1
+
+- Add project URLs to pyproject.toml and PyPI
+- Use ActionLint v2
+- Fix GitHub release action
+
 ## 2023/11/23 Version 11.1.0
 
 - Generate a man page with Sphinx (in addition to mkdocs HTML)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyee"
-version = "11.1.0"
+version = "11.1.1"
 authors = [
   {name = "Josh Holbrook", email = "josh.holbrook@gmail.com"}
 ]


### PR DESCRIPTION
ActionLint was reporting that the action I was using to create a GitHub release was deprecated. So, I went back to the drawing board.

First, I found [a fork of the origin GitHub release action](https://github.com/comnoco/create-release-action), and I slapped that in place. It has significant differences from the one I was using, namely that it didn't support uploading files. So I then followed [this blog post](https://michael-mckenna.com/how-to-upload-file-to-github-release-in-a-workflow/) and manually added the files with the `gh` CLI.

Of course, now I'm wondering if the blessed path is, in fact, to use the CLI to create the release.