### PR TITLE
wait for or cancel running asyncio tasks in an event emitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   - `complete` property that's `True` when no handlers are currently running
 - Updated changelog for v12 release to describe where to find alternatives
   to deprecated and removed imports
+- Upgrade GitHub Actions
+ - Upgrade `actions/setup-python` to v5
+ - Upgrade `actions/setup-node` to v4
+ - Upgrade `actions/upload-artifact` to v4
 
 ## 2024/08/30 Version 12.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,31 @@
 # Changelog
 
+## Next
+
+- New features in `pyee.asyncio.AsyncIOEventEmitter`:
+  - `wait_for_complete` method to wait for all running handlers to complete
+    execution
+  - `cancel` method to cancel execution of all running handlers
+  - `complete` property that's `True` when no handlers are currently running
+- Updated changelog for v12 release to describe where to find alternatives
+  to deprecated and removed imports
+
 ## 2024/08/30 Version 12.0.0
 
 - Remove deprecated imports:
   - `pyee.BaseEventEmitter`
+    - Use `pyee.base.EventEmitter` or `pyee.EventEmitter` instead
   - `pyee.AsyncIOEventEmitter`
+    - Use `pyee.asyncio.AsyncIOEventEmitter` instead
   - `pyee.TwistedEventEmitter`
+    - Use `pyee.twisted.TwistedEventEmitter` instead
   - `pyee.ExecutorEventEmitter`
+    - Use `pyee.executor.ExecutorEventEmitter` instead
   - `pyee.TrioEventEmitter`
+    - Use `pyee.trio.TrioEventEmitter` instead
 - Add `PyeeError` which inherits from `PyeeException`, and use throughout
 - Deprecate direct use of `PyeeException`
+  - Use `PyeeError` instead
 
 ## 2024/08/30 Version 11.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - `complete` property that's `True` when no handlers are currently running
 - Updated changelog for v12 release to describe where to find alternatives
   to deprecated and removed imports
+- Add support for Python 3.13
 - Upgrade GitHub Actions
  - Upgrade `actions/setup-python` to v5
  - Upgrade `actions/setup-node` to v4

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,3 +15,4 @@ Listed in no particular order:
 - Ivan Gretchka @leirons
 - Max Schmitt @mxschmitt
 - Masaya Suzuki @massongit
+- Xiao Shuai @xiaoshuai

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See [CHANGELOG.md](./CHANGELOG.md).
 
 ## Contributors
 
-See [ONTRIBUTORS.,md](./CONTRIBUTORS.md).
+See [CONTRIBUTORS.md](./CONTRIBUTORS.md).
 
 ## License
 

--- a/pyee/asyncio.py
+++ b/pyee/asyncio.py
@@ -67,7 +67,7 @@ class AsyncIOEventEmitter(EventEmitter):
                 return
 
             def callback(f):
-                self._waiting.remove(f)
+                self._waiting.discard(f)
 
                 if f.cancelled():
                     return
@@ -78,3 +78,15 @@ class AsyncIOEventEmitter(EventEmitter):
 
             fut.add_done_callback(callback)
             self._waiting.add(fut)
+
+    async def wait_for_all(self):
+        if self._waiting:
+            await asyncio.wait(self._waiting)
+
+    def cancel_all(self):
+        for fut in self._waiting:
+            fut.cancel()
+        self._waiting.clear()
+
+    def has_pending_tasks(self) -> bool:
+        return bool(self._waiting)

--- a/pyee/asyncio.py
+++ b/pyee/asyncio.py
@@ -80,13 +80,22 @@ class AsyncIOEventEmitter(EventEmitter):
             self._waiting.add(fut)
 
     async def wait_for_all(self):
+        """
+        Wait for all pending futures to complete
+        """
         if self._waiting:
             await asyncio.wait(self._waiting)
 
     def cancel_all(self):
+        """
+        Cancel all pending tasks
+        """
         for fut in self._waiting:
             fut.cancel()
         self._waiting.clear()
 
     def has_pending_tasks(self) -> bool:
+        """
+        Check if there are any pending tasks
+        """
         return bool(self._waiting)

--- a/pyee/asyncio.py
+++ b/pyee/asyncio.py
@@ -81,7 +81,7 @@ class AsyncIOEventEmitter(EventEmitter):
 
     async def wait_for_all(self):
         """
-        Wait for all pending futures to complete
+        Wait for all pending tasks to complete
         """
         if self._waiting:
             await asyncio.wait(self._waiting)
@@ -91,7 +91,8 @@ class AsyncIOEventEmitter(EventEmitter):
         Cancel all pending tasks
         """
         for fut in self._waiting:
-            fut.cancel()
+            if not fut.done() and not fut.cancelled():
+                fut.cancel()
         self._waiting.clear()
 
     def has_pending_tasks(self) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Other/Nonlisted Topic",
 ]
 requires-python = ">=3.8"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -51,8 +51,6 @@ comm==0.2.1
     # via ipykernel
 constantly==23.10.4
     # via twisted
-cryptography==42.0.4
-    # via secretstorage
 debugpy==1.8.0
     # via ipykernel
 decorator==5.1.1
@@ -94,7 +92,7 @@ importlib-metadata==7.0.1
     # via
     #   trio-typing
     #   twine
-incremental==22.10.0
+incremental==24.7.2
     # via twisted
 iniconfig==2.0.0
     # via pytest
@@ -110,10 +108,6 @@ jaraco-classes==3.3.1
     # via keyring
 jedi==0.19.1
     # via ipython
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.4
     # via
     #   mkdocs

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import asyncio
-from asyncio import Future, wait_for
+from asyncio import Future, sleep, wait_for
 
 import pytest
 import pytest_asyncio.plugin  # noqa
@@ -24,7 +24,7 @@ class PyeeTestError(Exception):
 
 
 @pytest.mark.asyncio
-async def test_asyncio_emit(event_loop):
+async def test_asyncio_emit(event_loop) -> None:
     """Test that AsyncIOEventEmitter can handle wrapping
     coroutines
     """
@@ -44,11 +44,11 @@ async def test_asyncio_emit(event_loop):
     assert result is True
 
     await asyncio.sleep(0)
-    assert len(ee._waiting) == 0
+    assert ee.complete
 
 
 @pytest.mark.asyncio
-async def test_asyncio_once_emit(event_loop):
+async def test_asyncio_once_emit(event_loop) -> None:
     """Test that AsyncIOEventEmitter also wrap coroutines when
     using once
     """
@@ -69,7 +69,7 @@ async def test_asyncio_once_emit(event_loop):
 
 
 @pytest.mark.asyncio
-async def test_asyncio_error(event_loop):
+async def test_asyncio_error(event_loop) -> None:
     """Test that AsyncIOEventEmitter can handle errors when
     wrapping coroutines
     """
@@ -93,8 +93,8 @@ async def test_asyncio_error(event_loop):
 
 
 @pytest.mark.asyncio
-async def test_asyncio_cancellation(event_loop):
-    """Test that AsyncIOEventEmitter can handle Future cancellations"""
+async def test_asyncio_future_canceled(event_loop) -> None:
+    """Test that AsyncIOEventEmitter can handle canceled Futures"""
 
     cancel_me = Future(loop=event_loop)
     should_not_call = Future(loop=event_loop)
@@ -120,7 +120,62 @@ async def test_asyncio_cancellation(event_loop):
 
 
 @pytest.mark.asyncio
-async def test_sync_error(event_loop):
+async def test_asyncio_event_emitter_canceled(event_loop) -> None:
+    """Test that all running handlers in AsyncIOEventEmitter can be canceled"""
+
+    ee = AsyncIOEventEmitter(loop=event_loop)
+
+    should_not_call = Future(loop=event_loop)
+
+    @ee.on("event")
+    async def event_handler():
+        await sleep(1)
+        should_not_call.set_result(True)
+
+    ee.emit("event")
+
+    await sleep(0)
+
+    # event_handler should still be running
+    assert not ee.complete
+
+    # cancel all pending tasks, including event_handler
+    ee.cancel()
+
+    await sleep(0)
+
+    # event_handler should be canceled
+    assert ee.complete
+
+
+@pytest.mark.asyncio
+async def test_asyncio_wait_for_complete(event_loop) -> None:
+    """Test waiting for all pending tasks in an AsyncIOEventEmitter to
+    complete
+    """
+
+    ee = AsyncIOEventEmitter(loop=event_loop)
+
+    @ee.on("event")
+    async def event_handler():
+        await sleep(0.1)
+
+    ee.emit("event")
+
+    await sleep(0)
+
+    # event_handler should still be running
+    assert not ee.complete
+
+    # wait for event_handler to complete execution
+    await ee.wait_for_complete()
+
+    # event_handler should have finished execution
+    assert ee.complete
+
+
+@pytest.mark.asyncio
+async def test_sync_error(event_loop) -> None:
     """Test that regular functions have the same error handling as coroutines"""
     ee = AsyncIOEventEmitter(loop=event_loop)
 
@@ -141,7 +196,7 @@ async def test_sync_error(event_loop):
     assert isinstance(result, PyeeTestError)
 
 
-def test_twisted_emit():
+def test_twisted_emit() -> None:
     """Test that TwistedEventEmitter can handle wrapping
     coroutines
     """
@@ -159,7 +214,7 @@ def test_twisted_emit():
     should_call.assert_called_once()
 
 
-def test_twisted_once():
+def test_twisted_once() -> None:
     """Test that TwistedEventEmitter also wraps coroutines for
     once
     """
@@ -177,7 +232,7 @@ def test_twisted_once():
     should_call.assert_called_once()
 
 
-def test_twisted_error():
+def test_twisted_error() -> None:
     """Test that TwistedEventEmitters handle Failures when wrapping coroutines."""
     ee = TwistedEventEmitter()
 

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import asyncio
-from asyncio import Future, sleep, wait_for
+from asyncio import Future, get_running_loop, sleep, wait_for
 
 import pytest
 import pytest_asyncio.plugin  # noqa
@@ -19,14 +19,14 @@ class PyeeTestError(Exception):
 
 
 @pytest.mark.asyncio
-async def test_emit(event_loop) -> None:
+async def test_emit() -> None:
     """Test that AsyncIOEventEmitter can handle wrapping
     coroutines
     """
 
-    ee = AsyncIOEventEmitter(loop=event_loop)
+    ee = AsyncIOEventEmitter(loop=get_running_loop())
 
-    should_call = Future(loop=event_loop)
+    should_call = Future(loop=get_running_loop())
 
     @ee.on("event")
     async def event_handler():
@@ -43,14 +43,14 @@ async def test_emit(event_loop) -> None:
 
 
 @pytest.mark.asyncio
-async def test_once_emit(event_loop) -> None:
+async def test_once_emit() -> None:
     """Test that AsyncIOEventEmitter also wrap coroutines when
     using once
     """
 
-    ee = AsyncIOEventEmitter(loop=event_loop)
+    ee = AsyncIOEventEmitter(loop=get_running_loop())
 
-    should_call = Future(loop=event_loop)
+    should_call = Future(loop=get_running_loop())
 
     @ee.once("event")
     async def event_handler():
@@ -64,13 +64,13 @@ async def test_once_emit(event_loop) -> None:
 
 
 @pytest.mark.asyncio
-async def test_error(event_loop) -> None:
+async def test_error() -> None:
     """Test that AsyncIOEventEmitter can handle errors when
     wrapping coroutines
     """
-    ee = AsyncIOEventEmitter(loop=event_loop)
+    ee = AsyncIOEventEmitter(loop=get_running_loop())
 
-    should_call = Future(loop=event_loop)
+    should_call = Future(loop=get_running_loop())
 
     @ee.on("event")
     async def event_handler():
@@ -88,13 +88,13 @@ async def test_error(event_loop) -> None:
 
 
 @pytest.mark.asyncio
-async def test_future_canceled(event_loop) -> None:
+async def test_future_canceled() -> None:
     """Test that AsyncIOEventEmitter can handle canceled Futures"""
 
-    cancel_me = Future(loop=event_loop)
-    should_not_call = Future(loop=event_loop)
+    cancel_me = Future(loop=get_running_loop())
+    should_not_call = Future(loop=get_running_loop())
 
-    ee = AsyncIOEventEmitter(loop=event_loop)
+    ee = AsyncIOEventEmitter(loop=get_running_loop())
 
     @ee.on("event")
     async def event_handler():
@@ -115,12 +115,12 @@ async def test_future_canceled(event_loop) -> None:
 
 
 @pytest.mark.asyncio
-async def test_event_emitter_canceled(event_loop) -> None:
+async def test_event_emitter_canceled() -> None:
     """Test that all running handlers in AsyncIOEventEmitter can be canceled"""
 
-    ee = AsyncIOEventEmitter(loop=event_loop)
+    ee = AsyncIOEventEmitter(loop=get_running_loop())
 
-    should_not_call = Future(loop=event_loop)
+    should_not_call = Future(loop=get_running_loop())
 
     @ee.on("event")
     async def event_handler():
@@ -144,12 +144,12 @@ async def test_event_emitter_canceled(event_loop) -> None:
 
 
 @pytest.mark.asyncio
-async def test_wait_for_complete(event_loop) -> None:
+async def test_wait_for_complete() -> None:
     """Test waiting for all pending tasks in an AsyncIOEventEmitter to
     complete
     """
 
-    ee = AsyncIOEventEmitter(loop=event_loop)
+    ee = AsyncIOEventEmitter(loop=get_running_loop())
 
     @ee.on("event")
     async def event_handler():
@@ -170,11 +170,11 @@ async def test_wait_for_complete(event_loop) -> None:
 
 
 @pytest.mark.asyncio
-async def test_sync_error(event_loop) -> None:
+async def test_sync_error() -> None:
     """Test that regular functions have the same error handling as coroutines"""
-    ee = AsyncIOEventEmitter(loop=event_loop)
+    ee = AsyncIOEventEmitter(loop=get_running_loop())
 
-    should_call = Future(loop=event_loop)
+    should_call = Future(loop=get_running_loop())
 
     @ee.on("event")
     def sync_handler():

--- a/tests/test_twisted.py
+++ b/tests/test_twisted.py
@@ -12,6 +12,7 @@ from pyee.twisted import TwistedEventEmitter
 class PyeeTestError(Exception):
     pass
 
+
 def test_emit() -> None:
     """Test that TwistedEventEmitter can handle wrapping
     coroutines
@@ -65,6 +66,7 @@ def test_error() -> None:
     ee.emit("event")
 
     should_call.assert_called_once()
+
 
 def test_propagates_failure():
     """Test that TwistedEventEmitters can propagate failures


### PR DESCRIPTION
This PR builds off #167:

* Rename methods to `wait_for_complete`, `cancel` and `complete`
* Adds full docstrings with examples to these new methods
* Adds test coverage for these new methods
* Separates twisted and asyncio tests. Twisted and asyncio tests were mixed in `./tests/test_async.py` because a prior iteration of this library supported both in the same event emitter abstraction. Now `./tests/test_async.py` has been renamed to `./tests/test_asyncio.py` and Twisted tests have been moved into `./tests/test_twisted.py` with the other Twisted tests
* Added @xiaoshuai to CONTRIBUTORS.md

I also investigated adding analogous features to other event emitters, but I don't think the other supported frameworks quite have the same execution/cancelation model as asyncio - certainly none of them hold explicit references to their futures.