### PR TITLE
GitHub Actions Upgrades, Nov 2024

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -28,11 +28,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up Node.js LTS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
       - name: Install the world

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ needs.versions.outputs.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ needs.versions.outputs.python-version }}"
       - name: Install the world
@@ -41,14 +41,14 @@ jobs:
       - name: Build Package Distributions
         run: python -m build
       - name: Store Package Distributions
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: package-distributions
           path: dist/
       - name: Build Man Page
         run: sphinx-build -M man docs _build
       - name: Store Man Page
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: man-page
           path: _build/man
@@ -56,7 +56,7 @@ jobs:
         # thanks to https://gist.github.com/Integralist/57accaf446cf3e7974cd01d57158532c
         run: mkdir notes && awk '/^##/ {block++} {if (block == 1) { print }}' CHANGELOG.md > notes/RELEASE.md
       - name: Store Release Notes
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-notes
           path: notes


### PR DESCRIPTION
* Upgrade `actions/setup-python` to v5
* Upgrade `actions/setup-node` to v4
* Upgrade `actions/upload-artifact` to v4

This PR should end with no errors or warnings from CI.

Closes #162