### PR TITLE
Overload EventEmitter.on type to avoid mypy errors

### DIFF
--- a/pyee/base.py
+++ b/pyee/base.py
@@ -9,6 +9,7 @@ from typing import (
     List,
     Mapping,
     Optional,
+    overload,
     Set,
     Tuple,
     TypeVar,
@@ -72,6 +73,10 @@ class EventEmitter:
         self.__dict__.update(state)
         self._lock = Lock()
 
+    @overload
+    def on(self, event: str) -> Callable[[Handler], Handler]: ...
+    @overload
+    def on(self, event: str, f: Handler) -> Handler: ...
     def on(
         self, event: str, f: Optional[Handler] = None
     ) -> Union[Handler, Callable[[Handler], Handler]]:

--- a/pyee/base.py
+++ b/pyee/base.py
@@ -77,6 +77,7 @@ class EventEmitter:
     def on(self, event: str) -> Callable[[Handler], Handler]: ...
     @overload
     def on(self, event: str, f: Handler) -> Handler: ...
+
     def on(
         self, event: str, f: Optional[Handler] = None
     ) -> Union[Handler, Callable[[Handler], Handler]]:


### PR DESCRIPTION
Hi,

when you use `mypy` as a type checker, it emits the following error like this.
```python
# ee.py
from pyee.base import EventEmitter

ee = EventEmitter()

@ee.on('event')
def event_handler():
    print('BANG BANG')
```

```
$ mypy --version
mypy 1.15.0 (compiled: yes)
$ mypy ee.py
ee.py:5: error: Argument 1 has incompatible type "Callable[[], Any]"; expected "Never"  [arg-type]
Found 1 error in 1 file (checked 1 source file)
```

So it would be helpful if type overloads like this PR is introduced.

Thanks!