### PR TITLE
Hide private members from `pyee.cls` exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## yyyy/mm/dd Version 14.0.0
+
+- Remove private members from `pyee.cls` exports
+  - `pyee.cls.Handler`
+  - `pyee.cls.Handlers`
+  - `pyee.cls._bind`
+
 ## 2025/03/17 Version 13.0.0
 
 - Type checking improvements

--- a/pyee/cls.py
+++ b/pyee/cls.py
@@ -4,6 +4,8 @@ from typing import Any, Callable, Iterator, List, Type, TypeVar
 
 from pyee import EventEmitter
 
+__all__ = ["on", "Cls", "evented"]
+
 
 @dataclass
 class Handler:


### PR DESCRIPTION
This PR removes the following exports:

- `pyee.cls.Handler`
- `pyee.cls.Handlers`
- `pyee.cls._bind`

These are all private members, and should not be needed by users of `pyee.cls`. Even so, this should be handled in a major version bump.