### PR TITLE
Adjust pytest configuration to support pytest 9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ known_application = "pyee"
 [tool.pyright]
 include = ["pyee", "tests"]
 
-[tool.pytest]
+[tool.pytest.ini_options]
 addopts = "--verbose -s"
 testpaths = [ "tests" ]
 


### PR DESCRIPTION
`[tool.pytest]` is now parsed as TOML.

Fixes: #189