### PR TITLE
Fix remove_all_listeners leaving stale empty event key

### DIFF
--- a/pyee/base.py
+++ b/pyee/base.py
@@ -275,7 +275,8 @@ class EventEmitter:
         """
         with self._lock:
             if event is not None:
-                self._events[event] = OrderedDict()
+                if event in self._events:
+                    del self._events[event]
             else:
                 self._events = dict()
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -135,40 +135,6 @@ def test_listener_removal():
     assert ee.event_names() == set()
 
 
-def test_remove_all_listeners_single_event_cleans_key():
-    """`remove_all_listeners("event")` fully removes the event key rather
-    than leaving an empty mapping behind.
-
-    Regression test: a previous implementation replaced the entry with an
-    empty ``OrderedDict``, which kept the key present in ``_events`` and
-    caused ``event_names()`` to wrongly report the event as still
-    registered.
-    """
-
-    ee = EventEmitter()
-
-    @ee.on("event")
-    def event_handler():
-        pass
-
-    @ee.on("other")
-    def other_handler():
-        pass
-
-    assert ee.event_names() == {"event", "other"}
-
-    ee.remove_all_listeners("event")
-
-    # The key must be gone entirely, not just emptied.
-    assert "event" not in ee._events
-    # event_names() must reflect the removal.
-    assert ee.event_names() == {"other"}
-    # The other event's listeners are untouched.
-    assert ee.listeners("other") == [other_handler]
-    # Emitting the removed event reports no handlers.
-    assert ee.emit("event") is False
-
-
 def test_remove_all_listeners_clears_every_event():
     """`remove_all_listeners()` with no argument removes every event."""
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -131,7 +131,65 @@ def test_listener_removal():
     assert ee._events["event"] == OrderedDict([(third, third), (fourth, fourth)])
 
     ee.remove_all_listeners("event")
-    assert "event" not in ee._events["event"]
+    assert "event" not in ee._events
+    assert ee.event_names() == set()
+
+
+def test_remove_all_listeners_single_event_cleans_key():
+    """`remove_all_listeners("event")` fully removes the event key rather
+    than leaving an empty mapping behind.
+
+    Regression test: a previous implementation replaced the entry with an
+    empty ``OrderedDict``, which kept the key present in ``_events`` and
+    caused ``event_names()`` to wrongly report the event as still
+    registered.
+    """
+
+    ee = EventEmitter()
+
+    @ee.on("event")
+    def event_handler():
+        pass
+
+    @ee.on("other")
+    def other_handler():
+        pass
+
+    assert ee.event_names() == {"event", "other"}
+
+    ee.remove_all_listeners("event")
+
+    # The key must be gone entirely, not just emptied.
+    assert "event" not in ee._events
+    # event_names() must reflect the removal.
+    assert ee.event_names() == {"other"}
+    # The other event's listeners are untouched.
+    assert ee.listeners("other") == [other_handler]
+    # Emitting the removed event reports no handlers.
+    assert ee.emit("event") is False
+
+
+def test_remove_all_listeners_clears_every_event():
+    """`remove_all_listeners()` with no argument removes every event."""
+
+    ee = EventEmitter()
+
+    @ee.on("a")
+    def a_handler():
+        pass
+
+    @ee.on("b")
+    def b_handler():
+        pass
+
+    assert ee.event_names() == {"a", "b"}
+
+    ee.remove_all_listeners()
+
+    assert ee._events == dict()
+    assert ee.event_names() == set()
+    assert ee.emit("a") is False
+    assert ee.emit("b") is False
 
 
 def test_listener_removal_on_emit():


### PR DESCRIPTION
`EventEmitter.remove_all_listeners("event")` replaced the event's `OrderedDict` with an empty one rather than deleting the key:

```python
# before
if event is not None:
    self._events[event] = OrderedDict()
```

As a result the event key remained present in `_events`, and `event_names()` kept reporting the event as registered even though it had no listeners. This was inconsistent with `_remove_listener`, which correctly `del`s the key when a mapping drains.


The fix is deleting the key, the same as `_remove_listener`